### PR TITLE
Update param name to match IWebHookHandler

### DIFF
--- a/samples/GenericReceivers/WebHooks/GenericJsonWebHookHandler.cs
+++ b/samples/GenericReceivers/WebHooks/GenericJsonWebHookHandler.cs
@@ -12,7 +12,7 @@ namespace GenericReceivers.WebHooks
             this.Receiver = "genericjson";
         }
 
-        public override Task ExecuteAsync(string generator, WebHookHandlerContext context)
+        public override Task ExecuteAsync(string receiver, WebHookHandlerContext context)
         {
             // Get JSON from WebHook
             JObject data = context.GetDataOrDefault<JObject>();


### PR DESCRIPTION
This class doesn't seem to use the param, so shouldn't effect anything but it should be consistently named.