### PR TITLE
Enforce mandatory properties in Azure Alert payload

### DIFF
--- a/src/Microsoft.AspNet.WebHooks.Receivers.Azure/WebHooks/AzureAlertContext.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Azure/WebHooks/AzureAlertContext.cs
@@ -14,79 +14,80 @@ namespace Microsoft.AspNet.WebHooks
         /// <summary>
         /// Gets or sets the unique ID for this alert.
         /// </summary>
-        [JsonProperty("id")]
+        [JsonProperty("id", Required = Required.Always)]
         public string Id { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the alert.
         /// </summary>
-        [JsonProperty("name")]
+        [JsonProperty("name", Required = Required.Always)]
         public string Name { get; set; }
 
         /// <summary>
         /// Gets or sets the description of the alert.
         /// </summary>
-        [JsonProperty("description")]
+        [JsonProperty("description", Required = Required.Always)]
         public string Description { get; set; }
 
         /// <summary>
         /// Gets or sets the condition type, e.g. '<c>Metric</c>' or '<c>Event</c>'.
         /// </summary>
-        [JsonProperty("conditionType")]
+        [JsonProperty("conditionType", Required = Required.Always)]
         public string ConditionType { get; set; }
 
         /// <summary>
         /// Gets or sets the Azure subscription ID.
         /// </summary>
-        [JsonProperty("subscriptionId")]
+        [JsonProperty("subscriptionId", Required = Required.Always)]
         public string SubscriptionId { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the alert was triggered. The alert is triggered as soon as 
         /// the metric is read from the diagnostics storage.
         /// </summary>
-        [JsonProperty("timestamp")]
+        [JsonProperty("timestamp", Required = Required.Always)]
         public DateTime Timestamp { get; set; }
 
         /// <summary>
         /// Gets or sets information about the condition causing the event.
         /// </summary>
+        [JsonProperty("condition", Required = Required.Always)]
         public AzureAlertCondition Condition { get; set; }
 
         /// <summary>
         /// Gets or sets the resource group name of the impacted resource causing the alert.
         /// </summary>
-        [JsonProperty("resourceGroupName")]
+        [JsonProperty("resourceGroupName", Required = Required.Always)]
         public string ResourceGroupName { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the resource causing the alert.
         /// </summary>
-        [JsonProperty("resourceName")]
+        [JsonProperty("resourceName", Required = Required.Always)]
         public string ResourceName { get; set; }
 
         /// <summary>
         /// Gets or sets the type of the impacted resource.
         /// </summary>
-        [JsonProperty("resourceType")]
+        [JsonProperty("resourceType", Required = Required.Always)]
         public string ResourceType { get; set; }
 
         /// <summary>
         /// Gets or sets the ID of the resource.
         /// </summary>
-        [JsonProperty("resourceId")]
+        [JsonProperty("resourceId", Required = Required.Always)]
         public string ResourceId { get; set; }
 
         /// <summary>
         /// Gets or sets the region where the resource is located.
         /// </summary>
-        [JsonProperty("resourceRegion")]
+        [JsonProperty("resourceRegion", Required = Required.Always)]
         public string ResourceRegion { get; set; }
 
         /// <summary>
         /// Gets or sets a direct link to the resource summary page on the Azure portal.
         /// </summary>
-        [JsonProperty("portalLink")]
+        [JsonProperty("portalLink", Required = Required.Always)]
         public string PortalLink { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Azure/WebHooks/AzureAlertNotification.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Azure/WebHooks/AzureAlertNotification.cs
@@ -17,13 +17,13 @@ namespace Microsoft.AspNet.WebHooks
         /// Gets or sets the kind of alert. Azure automatically sends activated and resolved alerts for the condition sets.
         /// Examples of values include '<c>Activated</c>' and '<c>Resolved</c>'.
         /// </summary>
-        [JsonProperty("status")]
+        [JsonProperty("status", Required = Required.Always)]
         public string Status { get; set; }
 
         /// <summary>
         /// Gets or sets context information for this alert.
         /// </summary>
-        [JsonProperty("context")]
+        [JsonProperty("context", Required = Required.Always)]
         public AzureAlertContext Context { get; set; }
 
         /// <summary>

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Azure/WebHooks/KuduNotification.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Azure/WebHooks/KuduNotification.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNet.WebHooks
     public class KuduNotification
     {
         /// <summary>
-        /// Gets or sets the ID or the WebHook.
+        /// Gets or sets the ID of the WebHook.
         /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; }
@@ -42,7 +42,7 @@ namespace Microsoft.AspNet.WebHooks
         public string Author { get; set; }
 
         /// <summary>
-        /// Gets or set a message contained within the WebHook.
+        /// Gets or sets a message contained within the WebHook.
         /// </summary>
         [JsonProperty("message")]
         public string Message { get; set; }

--- a/test/Microsoft.AspNet.WebHooks.Receivers.Azure.Test/Messages/AlertMessage1.json
+++ b/test/Microsoft.AspNet.WebHooks.Receivers.Azure.Test/Messages/AlertMessage1.json
@@ -19,6 +19,7 @@
     "timestamp": "2015-09-30T03:55:30.7037012Z",
     "resourceName": "testmachine",
     "resourceType": "microsoft.classiccompute/virtualmachines",
+    "resourceRegion": "West US",
     "resourceId": "/subscriptions/aaaaaaa-bbbb-cccc-ddd-eeeeeeeeeeeee/resourceGroups/tests123/providers/Microsoft.ClassicCompute/virtualMachines/testmachine",
     "portalLink": "https://portal.azure.com/#resource/subscriptions/aaaaaaa-bbbb-cccc-ddd-eeeeeeeeeeeee/resourceGroups/tests123/providers/Microsoft.ClassicCompute/virtualMachines/testmachine"
   },

--- a/test/Microsoft.AspNet.WebHooks.Receivers.Azure.Test/Messages/AlertMessage3.json
+++ b/test/Microsoft.AspNet.WebHooks.Receivers.Azure.Test/Messages/AlertMessage3.json
@@ -1,0 +1,31 @@
+﻿// Reference example from Azure documentation at https://azure.microsoft.com/en-us/documentation/articles/insights-webhooks-alerts/
+{
+  "status": "Activated",
+  "context": {
+    "timestamp": "2015-08-14T22:26:41.9975398Z",
+    "id": "/subscriptions/s1/resourceGroups/useast/providers/microsoft.insights/alertrules/ruleName1",
+    "name": "ruleName1",
+    "description": "some description",
+    "conditionType": "Metric",
+    "condition": {
+      "metricName": "Requests",
+      "metricUnit": "Count",
+      "metricValue": "10",
+      "threshold": "10",
+      "windowSize": "15",
+      "timeAggregation": "Average",
+      "operator": "GreaterThanOrEqual"
+    },
+    "subscriptionId": "s1",
+    "resourceGroupName": "useast",
+    "resourceName": "mysite1",
+    "resourceType": "microsoft.foo/sites",
+    "resourceId": "/subscriptions/s1/resourceGroups/useast/providers/microsoft.foo/sites/mysite1",
+    "resourceRegion": "centralus",
+    "portalLink": "https://portal.azure.com/#resource/subscriptions/s1/resourceGroups/useast/providers/microsoft.foo/sites/mysite1"
+  },
+  "properties": {
+    "key1": "value1",
+    "key2": "value2"
+  }
+}

--- a/test/Microsoft.AspNet.WebHooks.Receivers.Azure.Test/Microsoft.AspNet.WebHooks.Receivers.Azure.Test.csproj
+++ b/test/Microsoft.AspNet.WebHooks.Receivers.Azure.Test/Microsoft.AspNet.WebHooks.Receivers.Azure.Test.csproj
@@ -75,6 +75,7 @@
     <EmbeddedResource Include="Messages\KuduMessage.json" />
     <EmbeddedResource Include="Messages\AlertMessage2.json" />
     <EmbeddedResource Include="Messages\AlertMessage1.json" />
+    <EmbeddedResource Include="Messages\AlertMessage3.json" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Microsoft.AspNet.WebHooks.Receivers.Azure.Test/WebHooks/AzureAlertContextTests.cs
+++ b/test/Microsoft.AspNet.WebHooks.Receivers.Azure.Test/WebHooks/AzureAlertContextTests.cs
@@ -46,6 +46,7 @@ namespace Microsoft.AspNet.WebHooks
                 Timestamp = DateTime.Parse("2015-09-30T03:55:30.7037012Z").ToUniversalTime(),
                 ResourceName = "testmachine",
                 ResourceType = "microsoft.classiccompute/virtualmachines",
+                ResourceRegion = "West US",
                 ResourceId = "/subscriptions/aaaaaaa-bbbb-cccc-ddd-eeeeeeeeeeeee/resourceGroups/tests123/providers/Microsoft.ClassicCompute/virtualMachines/testmachine",
                 PortalLink = "https://portal.azure.com/#resource/subscriptions/aaaaaaa-bbbb-cccc-ddd-eeeeeeeeeeeee/resourceGroups/tests123/providers/Microsoft.ClassicCompute/virtualMachines/testmachine",
             };
@@ -57,6 +58,18 @@ namespace Microsoft.AspNet.WebHooks
             string expectedJson = JsonConvert.SerializeObject(expected, _serializerSettings);
             string actualJson = JsonConvert.SerializeObject(actual, _serializerSettings);
             Assert.Equal(expectedJson, actualJson);
+        }
+
+        [Fact]
+        public void AlertContext_SubscriptionIdIsRequired()
+        {
+            // Arrange
+            JObject data = EmbeddedResource.ReadAsJObject("Microsoft.AspNet.WebHooks.Messages.AlertMessage3.json");
+            ((JObject)data["context"]).Property("subscriptionId").Remove();
+            var json = JsonConvert.SerializeObject(data["context"], _serializerSettings);
+
+            // Act / Assert
+            Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<AzureAlertContext>(json));
         }
     }
 }

--- a/test/Microsoft.AspNet.WebHooks.Receivers.Azure.Test/WebHooks/AzureAlertNotificationTests.cs
+++ b/test/Microsoft.AspNet.WebHooks.Receivers.Azure.Test/WebHooks/AzureAlertNotificationTests.cs
@@ -65,5 +65,19 @@ namespace Microsoft.AspNet.WebHooks
             string actualJson = JsonConvert.SerializeObject(actual, _serializerSettings);
             Assert.Equal(expectedJson, actualJson);
         }
+
+        [Fact]
+        public void AlertContext_ExampleInAzureDocumentationCanBeParsed()
+        {
+            // Arrange
+            JObject data = EmbeddedResource.ReadAsJObject("Microsoft.AspNet.WebHooks.Messages.AlertMessage3.json");
+
+            // Act
+            AzureAlertNotification actual = data.ToObject<AzureAlertNotification>();
+
+            // Assert
+            Assert.Equal("Activated", actual.Status);
+
+        }
     }
 }


### PR DESCRIPTION
- Tag mandatory properties with Required.Always so JSON.NET enforces the requirement during (de)serialization
- Fix a couple of comment typos on KuduNotification
- Add required 'resourceRegion' property to AlertMessage1.json test content
- Add AlertMessage3.json to validate change against sample payload in Azure docs
- Add unit tests