### PR TITLE
Added configuration key for Disable HTTPs check

### DIFF
--- a/samples/VstsReceiver/Web.config
+++ b/samples/VstsReceiver/Web.config
@@ -6,6 +6,7 @@
 <configuration>
   <appSettings>
     <add key="MS_WebHookReceiverSecret_VSTS" value="83699ec7c1d794c0c780e49a5c72972590571fd8"/>
+    <add key="MS_WebHookDisableHttpsCheck" value="false"/>
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.


### PR DESCRIPTION
When deploy to a private network, it's not necessary to use https. This helps the users to know how to do this.