### PR TITLE
Corrected WebHook URI

### DIFF
--- a/samples/BitbucketReceiver/index.html
+++ b/samples/BitbucketReceiver/index.html
@@ -9,7 +9,7 @@
 
     <p>This sample illustrates how to wire up a Bitbucket WebHooks receiver. A sample WebHook URI is:</p>
 
-    <pre>https://&lt;host&gt;/api/webhooks/incoming/bitbucket/{id}?code=83699ec7c1d794c0c780e49a5c72972590571fd8</pre>
+    <pre>https://&lt;host&gt;/api/webhooks/incoming/bitbucket/?code=83699ec7c1d794c0c780e49a5c72972590571fd8</pre>
 
     <p>
         For security reasons the WebHook URI must be an <c>https</c> URI and contain a 'code' query parameter with the


### PR DESCRIPTION
Corrected WebHook URI, we do not required {id} part for Bitbucket WebHook URI.