### PR TITLE
slack trigger can be optional 

### DIFF
--- a/src/Microsoft.AspNet.WebHooks.Receivers.Slack/Properties/SlackReceiverResources.Designer.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Slack/Properties/SlackReceiverResources.Designer.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNet.WebHooks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The HTTP request body did not contain a required &apos;{0}&apos; property indicating a slash command or a &apos;{1}&apos; property indicating an outgoing WebHook..
+        ///   Looks up a localized string similar to The HTTP request body did not contain a required &apos;{0}&apos; property indicating a slash command or contained an empty {1} parameter indicating an outgoing WebHook..
         /// </summary>
         internal static string Receiver_BadBody {
             get {

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Slack/Properties/SlackReceiverResources.resx
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Slack/Properties/SlackReceiverResources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Receiver_BadBody" xml:space="preserve">
-    <value>The HTTP request body did not contain a required '{0}' property indicating a slash command or a '{1}' property indicating an outgoing WebHook.</value>
+    <value>The HTTP request body did not contain a required '{0}' property indicating a slash command or contained an empty {1} parameter indicating an outgoing WebHook.</value>
   </data>
   <data name="Receiver_BadToken" xml:space="preserve">
     <value>The '{0}' parameter provided in the HTTP request did not match the expected value.</value>

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Slack/WebHooks/SlackWebHookReceiver.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Slack/WebHooks/SlackWebHookReceiver.cs
@@ -80,16 +80,26 @@ namespace Microsoft.AspNet.WebHooks
                 }
 
                 // Get the action by looking for either trigger_word or command parameter
-                string action = data[TriggerParameter];
-                if (!string.IsNullOrEmpty(action))
+                string action = string.Empty;
+                if (data[TriggerParameter] != null)
                 {
+                    // Trigger parameter was supplied
                     // Get the subtext by removing the trigger word
+                    action = data[TriggerParameter];
                     string text = data[TextParameter];
                     data[SubtextParameter] = GetSubtext(action, text);
                 }
+                else if (data[CommandParameter] != null)
+                {
+                    // Command parameter was supplied
+                    action = data[CommandParameter];
+                }
                 else
                 {
-                    action = data[CommandParameter];
+                    // Trigger was omitted as optional
+                    // Set the subtext to the full text
+                    action = data[TextParameter];
+                    data[SubtextParameter] = data[TextParameter];
                 }
 
                 if (string.IsNullOrEmpty(action))


### PR DESCRIPTION
Hi! I've just come across a scenario when using the Slack webhook where Slack isn't sending either a 'trigger_word' or a 'command' parameter. This happens when you configure the outgoing webhook for a specific channel. In that case, trigger words are optional.

To make my receiver work in that scenario, I had to remove the requirement in code.

Thank you for your consideration of this pull request!
Elena