### PR TITLE
SystemAssignedTo is missing in the WorkItemCreated payload

### DIFF
--- a/src/Microsoft.AspNet.WebHooks.Receivers.VSTS/Payloads/WorkItemFields.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.VSTS/Payloads/WorkItemFields.cs
@@ -48,6 +48,12 @@ namespace Microsoft.AspNet.WebHooks.Payloads
         public string SystemReason { get; set; }
 
         /// <summary>
+        /// Gets the value of field <c>System.AssignedTo</c>.
+        /// </summary>
+        [JsonProperty("System.AssignedTo")]
+        public string SystemAssignedTo { get; set; }
+        
+        /// <summary>
         /// Gets the value of field <c>System.CreatedDate</c>.
         /// </summary>
         [JsonProperty("System.CreatedDate")]


### PR DESCRIPTION
TFS WorkItemCreated payload can also contain System.AssignedTo field, which is missing in the definition right now.