### PR TITLE
Suggest changes to two quirky-looking bits

### DIFF
--- a/src/Microsoft.AspNet.WebHooks.Receivers.Salesforce/WebHooks/SalesforceSoapWebHookReceiver.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Salesforce/WebHooks/SalesforceSoapWebHookReceiver.cs
@@ -93,12 +93,28 @@ namespace Microsoft.AspNet.WebHooks
                 // Call registered handlers
                 var response = await ExecuteWebHookAsync(id, context, request, new string[] { action }, notifications);
 
-                // Add SOAP response if not already present
-                if (response == null || response.Content == null || !response.Content.IsXml())
+                // Add SOAP response content if not already present or isn't XML. Ignore current (e.g. JSON) content.
+                if (response?.Content == null || !response.Content.IsXml())
                 {
-                    var success = ReadResource("Microsoft.AspNet.WebHooks.Messages.NotificationResponse.xml");
-                    response = GetXmlResponse(request, HttpStatusCode.OK, success);
+                    // Ignore redirects because SOAP 1.1 doesn't mention them and they're corner cases in SOAP.
+                    var statusCode = response?.StatusCode ?? HttpStatusCode.OK;
+                    if (statusCode >= (HttpStatusCode)200 && statusCode < (HttpStatusCode)300)
+                    {
+                        var success = ReadResource("Microsoft.AspNet.WebHooks.Messages.NotificationResponse.xml");
+                        response = GetXmlResponse(request, statusCode, success);
+                    }
+                    else
+                    {
+                        // Move failure information into a SOAP fault response. Fault contains code soapenv:Client and
+                        // that must be transmitted with HTTP status 400, Bad Request according to SOAP 1.2 (mixing
+                        // that sensible choice into this SOAP 1.1 implementation).
+                        var resource = ReadResource("Microsoft.AspNet.WebHooks.Messages.FaultResponse.xml");
+                        var faultString = $"Handler's status: {statusCode}, '{response.ReasonPhrase}'.";
+                        var failure = string.Format(CultureInfo.InvariantCulture, resource, faultString);
+                        response = GetXmlResponse(request, HttpStatusCode.BadRequest, failure);
+                    }
                 }
+
                 return response;
             }
             else

--- a/src/Microsoft.AspNet.WebHooks.Receivers/Extensions/WebHookHandlerContextExtensions.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers/Extensions/WebHookHandlerContextExtensions.cs
@@ -30,16 +30,34 @@ namespace Microsoft.AspNet.WebHooks
                 return default(T);
             }
 
-            if (context.Data is JToken && !typeof(JToken).IsAssignableFrom(typeof(T)))
+            // IsAssignableFrom(...) check looks odd because return statement effectively assigns from Data to T.
+            // However, this check avoids useless "conversions" e.g. from a JObject to a JObject without attempting
+            // impossible conversions e.g. from a JObject to a JArray. Json.NET does not support semantically-invalid
+            // conversions between JToken subtypes.
+            //
+            // !typeof(T).IsAssignableFrom(context.Data.GetType()) may be more precise but is less efficient. That
+            // check would not change the (null) outcome in the JObject to JArray case, just adds a first-chance
+            // Exception (because the code would attempt the impossible conversion). About the only new cases it
+            // handles with a cast instead of ToObject<T>() are extreme corner cases such as when T is
+            // IDictionary<string, JToken> or another interface the current Data (e.g. JObject) may implement. Even
+            // then, Json.NET can usually perform an explicit conversion.
+            if (context.Data is JToken token && !typeof(JToken).IsAssignableFrom(typeof(T)))
             {
+                // context.Data is a JToken and the caller isn't just asking for (say) the current JObject.
+                // Do explicit conversion.
                 try
                 {
-                    var data = ((JToken)context.Data).ToObject<T>();
+                    var data = token.ToObject<T>();
                     return data;
                 }
                 catch (Exception ex)
                 {
-                    var message = string.Format(CultureInfo.CurrentCulture, ReceiverResources.GetDataOrDefault_Failure, context.Data.GetType(), typeof(T), ex.Message);
+                    var message = string.Format(
+                        CultureInfo.CurrentCulture,
+                        ReceiverResources.GetDataOrDefault_Failure,
+                        context.Data.GetType(),
+                        typeof(T),
+                        ex.Message);
                     context.RequestContext.Configuration.DependencyResolver.GetLogger().Error(message, ex);
                     return default(T);
                 }

--- a/test/Microsoft.AspNet.WebHooks.Receivers.Generic.Test/WebHooks/GenericJsonWebHookReceiverTests.cs
+++ b/test/Microsoft.AspNet.WebHooks.Receivers.Generic.Test/WebHooks/GenericJsonWebHookReceiverTests.cs
@@ -54,7 +54,6 @@ namespace Microsoft.AspNet.WebHooks
                     { string.Empty, "\"data\"" },
                     { "你好", "\"data\"" },
                     { "id", "\"data\"" },
-                    { "id", "\"data\"" },
                     { "id", "1234" },
                     { "id", "1234.5678" },
                     { "id", "{}" },


### PR DESCRIPTION
Update two quirky-looking bits of code
- use SOAP fault when Salesforce handler fails
  - preserve non-200 but successful HTTP status code
- add lots of comments about `IsAssignableFrom(...)` use in `GetDataOrDefault<T>(...)`
  - test this method more thoroughly

nits:
- use new C# features
- remove duplicate test data in `GenericJsonWebHookReceiverTests`
- take VS suggestions, especially in `WebHookHandlerContextExtensionsTests`