### PR TITLE
 Update `StripeEvent` to latest API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ _[Ss]cripts
 *.dot[Cc]over
 *.pubxml
 *.zip
+*launchSettings.json

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Stripe/Microsoft.AspNet.WebHooks.Receivers.Stripe.csproj
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Stripe/Microsoft.AspNet.WebHooks.Receivers.Stripe.csproj
@@ -66,6 +66,7 @@
     </Compile>
     <Compile Include="WebHooks\StripeEvent.cs" />
     <Compile Include="WebHooks\StripeEventData.cs" />
+    <Compile Include="WebHooks\StripeRequestData.cs" />
     <Compile Include="WebHooks\StripeWebHookReceiver.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Stripe/WebHooks/StripeEvent.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Stripe/WebHooks/StripeEvent.cs
@@ -26,14 +26,14 @@ namespace Microsoft.AspNet.WebHooks
         public string Object { get; set; }
 
         /// <summary>
-        /// Gets or sets the Stripe API version used to render data. 
+        /// Gets or sets the Stripe API version used to render data.
         /// Note: this property is populated for events on or after October 31, 2014.
         /// </summary>
         [JsonProperty("api_version")]
         public string ApiVersion { get; set; }
 
         /// <summary>
-        /// Gets or sets the time at which the alert was triggered. 
+        /// Gets or sets the time at which the alert was triggered.
         /// </summary>
         [JsonConverter(typeof(UnixTimeConverter))]
         [JsonProperty("created")]
@@ -52,20 +52,25 @@ namespace Microsoft.AspNet.WebHooks
         public bool LiveMode { get; set; }
 
         /// <summary>
-        /// Gets or sets the number of WebHooks yet to be delivered successfully 
+        /// Gets or sets the number of WebHooks yet to be delivered successfully
         /// (return a 20x response) to the URLs you’ve specified.
         /// </summary>
         [JsonProperty("pending_webhooks")]
         public int PendingWebHooks { get; set; }
 
         /// <summary>
-        /// Gets or sets ID of the API request that caused the event. 
-        /// If null, the event was automatic (e.g. Stripe’s automatic subscription handling). 
-        /// Request logs are available in the dashboard but currently not in the API. 
+        /// Gets the ID of the API request that caused the event.
+        /// If null, the event was automatic (e.g. Stripe’s automatic subscription handling).
+        /// Request logs are available in the dashboard but currently not in the API.
         /// Note: this property is populated for events on or after April 23, 2013.
         /// </summary>
+        public string Request => RequestData?.Id;
+
+        /// <summary>
+        /// Gets or sets the details of the API request that caused the event.
+        /// </summary>
         [JsonProperty("request")]
-        public string Request { get; set; }
+        public StripeRequestData RequestData { get; set; }
 
         /// <summary>
         /// Gets or sets the description of the event: e.g. invoice.created, charge.refunded, etc.

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Stripe/WebHooks/StripeRequestData.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Stripe/WebHooks/StripeRequestData.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.AspNet.WebHooks
+{
+    /// <summary>
+    /// Contains information sent in a WebHook notification from Stripe. Describes the API request that caused the
+    /// event. See <see href="https://stripe.com/docs/api/curl#event_object-request"/> for details.
+    /// </summary>
+    public class StripeRequestData
+    {
+        /// <summary>
+        /// Gets or sets the ID of the API request that caused the event.
+        /// </summary>
+        /// <value><see langword="null"/> if the event was automatic. Otherwise, the API request ID.</value>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the idempotency key transmitted in the API request.
+        /// </summary>
+        /// <remarks>This property is only populated for events on or after May 23, 2017.</remarks>
+        [JsonProperty("idempotency_key")]
+        public string IdempotencyKey { get; set; }
+    }
+}

--- a/test/Microsoft.AspNet.WebHooks.Receivers.Stripe.Test/Messages/StripeEvent.json
+++ b/test/Microsoft.AspNet.WebHooks.Receivers.Stripe.Test/Messages/StripeEvent.json
@@ -16,6 +16,8 @@
   },
   "livemode": true,
   "pending_webhooks": 10,
-  "request": "req_7nbnyKCObIkSXC",
+  "request": {
+    "id": "req_7nbnyKCObIkSXC"
+  },
   "type": "customer.source.created"
 }

--- a/test/Microsoft.AspNet.WebHooks.Receivers.Stripe.Test/WebHooks/StripeEventTests.cs
+++ b/test/Microsoft.AspNet.WebHooks.Receivers.Stripe.Test/WebHooks/StripeEventTests.cs
@@ -30,7 +30,10 @@ namespace Microsoft.AspNet.WebHooks
                 },
                 LiveMode = true,
                 PendingWebHooks = 10,
-                Request = "req_7nbnyKCObIkSXC",
+                RequestData = new StripeRequestData
+                {
+                    Id = "req_7nbnyKCObIkSXC",
+                },
                 EventType = "customer.source.created",
             };
 


### PR DESCRIPTION
- #154
- see https://stripe.com/docs/upgrades#2017-05-25
- provide readonly `StripeEvent.Request` property for ease of use

nits:
- remove trailing whitespace in `StripeEvent`
- ignore launchSettings.json files