### PR TITLE
More `$(Configurations)` muck

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,9 +21,6 @@
     <!-- Work around https://github.com/NuGet/Home/issues/4726 -->
     <IncludeSymbols Condition=" '$(NuspecFile)' != '' ">false</IncludeSymbols>
 
-    <!-- Let the new SDKs know about CodeAnalysis. -->
-    <Configurations>$(Configurations);CodeAnalysis</Configurations>
-
     <LangVersion>7.1</LangVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <NoPackageAnalysis>true</NoPackageAnalysis>

--- a/samples/AzureAlertCoreReceiver/AzureAlertCoreReceiver.csproj
+++ b/samples/AzureAlertCoreReceiver/AzureAlertCoreReceiver.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/samples/BitbucketCoreReceiver/BitbucketCoreReceiver.csproj
+++ b/samples/BitbucketCoreReceiver/BitbucketCoreReceiver.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/samples/BitbucketStronglyTypedCoreReceiver/BitbucketStronglyTypedCoreReceiver.csproj
+++ b/samples/BitbucketStronglyTypedCoreReceiver/BitbucketStronglyTypedCoreReceiver.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/samples/DropboxCoreReceiver/DropboxCoreReceiver.csproj
+++ b/samples/DropboxCoreReceiver/DropboxCoreReceiver.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/samples/DynamicsCRMCoreReceiver/DynamicsCRMCoreReceiver.csproj
+++ b/samples/DynamicsCRMCoreReceiver/DynamicsCRMCoreReceiver.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/samples/GitHubCoreReceiver/GitHubCoreReceiver.csproj
+++ b/samples/GitHubCoreReceiver/GitHubCoreReceiver.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/samples/KuduCoreReceiver/KuduCoreReceiver.csproj
+++ b/samples/KuduCoreReceiver/KuduCoreReceiver.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/samples/MailChimpCoreReceiver/MailChimpCoreReceiver.csproj
+++ b/samples/MailChimpCoreReceiver/MailChimpCoreReceiver.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/samples/PusherCoreReceiver/PusherCoreReceiver.csproj
+++ b/samples/PusherCoreReceiver/PusherCoreReceiver.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/samples/SalesforceCoreReceiver/SalesforceCoreReceiver.csproj
+++ b/samples/SalesforceCoreReceiver/SalesforceCoreReceiver.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/samples/SlackCoreReceiver/SlackCoreReceiver.csproj
+++ b/samples/SlackCoreReceiver/SlackCoreReceiver.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/samples/StripeCoreReceiver/StripeCoreReceiver.csproj
+++ b/samples/StripeCoreReceiver/StripeCoreReceiver.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.AzureAlert/Microsoft.AspNetCore.WebHooks.Receivers.AzureAlert.csproj
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.AzureAlert/Microsoft.AspNetCore.WebHooks.Receivers.AzureAlert.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <Description>ASP.NET Core Azure Alert WebHooks infrastructure. Contains the AzureAlertWebHookAttribute class and AddAzureAlertWebHooks method.</Description>
     <PackageTags>aspnetcore;webhook;receiver;azurealert</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.BitBucket/Microsoft.AspNetCore.WebHooks.Receivers.BitBucket.csproj
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.BitBucket/Microsoft.AspNetCore.WebHooks.Receivers.BitBucket.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <Description>ASP.NET Core Bitbucket WebHooks infrastructure. Contains the BitbucketWebHookAttribute class and AddBitbucketWebHooks method.</Description>
     <PackageTags>aspnetcore;webhook;receiver;bitbucket</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Dropbox/Microsoft.AspNetCore.WebHooks.Receivers.Dropbox.csproj
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Dropbox/Microsoft.AspNetCore.WebHooks.Receivers.Dropbox.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <Description>ASP.NET Core Dropbox WebHooks infrastructure. Contains the DropboxWebHookAttribute class and AddDropboxWebHooks method.</Description>
     <PackageTags>aspnetcore;webhook;receiver;dropbox</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.DynamicsCRM/Microsoft.AspNetCore.WebHooks.Receivers.DynamicsCRM.csproj
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.DynamicsCRM/Microsoft.AspNetCore.WebHooks.Receivers.DynamicsCRM.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <Description>ASP.NET Core Dynamics CRM WebHooks infrastructure. Contains the DynamicsCRMWebHookAttribute class and AddDynamicsCRMWebHooks method.</Description>
     <PackageTags>aspnetcore;webhook;receiver;dynamicscrm</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.GitHub/Microsoft.AspNetCore.WebHooks.Receivers.GitHub.csproj
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.GitHub/Microsoft.AspNetCore.WebHooks.Receivers.GitHub.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <Description>ASP.NET Core GitHub WebHooks infrastructure. Contains the GitHubWebHookAttribute class and AddGitHubWebHooks method.</Description>
     <PackageTags>aspnetcore;webhook;receiver;github</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Kudu/Microsoft.AspNetCore.WebHooks.Receivers.Kudu.csproj
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Kudu/Microsoft.AspNetCore.WebHooks.Receivers.Kudu.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <Description>ASP.NET Core Kudu WebHooks infrastructure. Contains the KuduWebHookAttribute class and AddKuduWebHooks method.</Description>
     <PackageTags>aspnetcore;webhook;receiver;kudu</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.MailChimp/Microsoft.AspNetCore.WebHooks.Receivers.MailChimp.csproj
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.MailChimp/Microsoft.AspNetCore.WebHooks.Receivers.MailChimp.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <Description>ASP.NET Core MailChimp WebHooks infrastructure. Contains the MailChimpWebHookAttribute class and AddMailChimpWebHooks method.</Description>
     <PackageTags>aspnetcore;webhook;receiver;mailchimp</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Pusher/Microsoft.AspNetCore.WebHooks.Receivers.Pusher.csproj
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Pusher/Microsoft.AspNetCore.WebHooks.Receivers.Pusher.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <Description>ASP.NET Core Pusher WebHooks infrastructure. Contains the PusherWebHookAttribute class and AddPusherWebHooks method.</Description>
     <PackageTags>aspnetcore;webhook;receiver;pusher</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce.csproj
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <Description>ASP.NET Core Salesforce WebHooks infrastructure. Contains the SalesforceWebHookAttribute class and AddSalesforceWebHooks method.</Description>
     <PackageTags>aspnetcore;webhook;receiver;salesforce</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/Microsoft.AspNetCore.WebHooks.Receivers.Slack.csproj
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/Microsoft.AspNetCore.WebHooks.Receivers.Slack.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <Description>ASP.NET Core Slack WebHooks infrastructure. Contains the SlackWebHookAttribute class and AddSlackWebHooks method.</Description>
     <PackageTags>aspnetcore;webhook;receiver;slack</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Stripe/Microsoft.AspNetCore.WebHooks.Receivers.Stripe.csproj
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Stripe/Microsoft.AspNetCore.WebHooks.Receivers.Stripe.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <Description>ASP.NET Core Stripe WebHooks infrastructure. Contains the StripeWebHookAttribute class and AddStripeWebHooks method.</Description>
     <PackageTags>aspnetcore;webhook;receiver;stripe</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Trello/Microsoft.AspNetCore.WebHooks.Receivers.Trello.csproj
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Trello/Microsoft.AspNetCore.WebHooks.Receivers.Trello.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <Description>ASP.NET Core Trello WebHooks infrastructure. Contains the TrelloWebHookAttribute class and AddTrelloWebHooks method.</Description>
     <PackageTags>aspnetcore;webhook;receiver;trello</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.WordPress/Microsoft.AspNetCore.WebHooks.Receivers.WordPress.csproj
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.WordPress/Microsoft.AspNetCore.WebHooks.Receivers.WordPress.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <Description>ASP.NET Core WordPress WebHooks infrastructure. Contains the WordPressWebHookAttribute class and AddWordPressWebHooks method.</Description>
     <PackageTags>aspnetcore;webhook;receiver;wordpress</PackageTags>
   </PropertyGroup>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Microsoft.AspNetCore.WebHooks.Receivers.csproj
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Microsoft.AspNetCore.WebHooks.Receivers.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
     <Description>ASP.NET Core WebHooks abstractions and infrastructure components for receivers. Contains constraints, filters, metadata, and the application models to apply them.</Description>
     <PackageTags>aspnetcore;webhook;receiver</PackageTags>
   </PropertyGroup>


### PR DESCRIPTION
- Visual Studio does not load Directory.Build.props when checking for `$(Configurations)` setting
- moving setting to projects stops VS rewriting the solution file