### PR TITLE
Simple renames

### DIFF
--- a/src/Microsoft.AspNet.WebHooks.Receivers/Properties/ReceiverResources.Designer.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers/Properties/ReceiverResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNet.WebHooks.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ReceiverResources {
@@ -151,7 +151,7 @@ namespace Microsoft.AspNet.WebHooks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The WebHook request contained invalid HTML Form Data: &apos;{0}&apos;..
+        ///   Looks up a localized string similar to The WebHook request contained invalid HTML form URL-encoded data: &apos;{0}&apos;..
         /// </summary>
         internal static string Receiver_BadFormData {
             get {
@@ -232,7 +232,7 @@ namespace Microsoft.AspNet.WebHooks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The WebHook request must contain an entity body formatted as HTML Form Data..
+        ///   Looks up a localized string similar to The WebHook request must contain an entity body formatted as HTML form URL-encoded data..
         /// </summary>
         internal static string Receiver_NoFormData {
             get {

--- a/src/Microsoft.AspNet.WebHooks.Receivers/Properties/ReceiverResources.resx
+++ b/src/Microsoft.AspNet.WebHooks.Receivers/Properties/ReceiverResources.resx
@@ -151,7 +151,7 @@
     <value>The '{0}' query parameter provided in the HTTP request did not match the expected value.</value>
   </data>
   <data name="Receiver_BadFormData" xml:space="preserve">
-    <value>The WebHook request contained invalid HTML Form Data: '{0}'.</value>
+    <value>The WebHook request contained invalid HTML form URL-encoded data: '{0}'.</value>
   </data>
   <data name="Receiver_BadHeader" xml:space="preserve">
     <value>Expecting exactly one '{0}' header field in the WebHook request but found {1}. Please ensure that the request contains exactly one '{0}' header field.</value>
@@ -178,7 +178,7 @@
     <value>The WebHook verification request must contain a '{0}' query parameter.</value>
   </data>
   <data name="Receiver_NoFormData" xml:space="preserve">
-    <value>The WebHook request must contain an entity body formatted as HTML Form Data.</value>
+    <value>The WebHook request must contain an entity body formatted as HTML form URL-encoded data.</value>
   </data>
   <data name="Receiver_NoHttps" xml:space="preserve">
     <value>The WebHook receiver '{0}' requires HTTPS in order to be secure. Please register a WebHook URI of type '{1}'.</value>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.GitHub/GitHubWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.GitHub/GitHubWebHookAttribute.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNetCore.WebHooks
         }
 
         /// <summary>
-        /// Gets or sets an indication this action expects form data.
+        /// Gets or sets an indication this action expects HTML form URL-encoded data.
         /// </summary>
         /// <value>Defaults to <see langword="false"/>, indicating this action expects JSON data.</value>
         public bool AcceptFormData { get; set; }

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Pusher/PusherConstants.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Pusher/PusherConstants.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.WebHooks
         /// <summary>
         /// Gets the name of the Pusher WebHook receiver.
         /// </summary>
-        public static string ReceiverName => "Pusher";
+        public static string ReceiverName => "pusher";
 
         /// <summary>
         /// Gets the minimum length of the secret key configured for this receiver.

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/Filters/SalesforceVerifyOrganizationIdFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/Filters/SalesforceVerifyOrganizationIdFilter.cs
@@ -147,7 +147,7 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
             }
 
             var secret = GetSecretKey(
-                SalesforceConstants.ConfigurationName,
+                ReceiverName,
                 routeData,
                 SalesforceConstants.SecretKeyMinLength,
                 SalesforceConstants.SecretKeyMaxLength);

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/SalesforceConstants.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/SalesforceConstants.cs
@@ -9,11 +9,6 @@ namespace Microsoft.AspNetCore.WebHooks
     public static class SalesforceConstants
     {
         /// <summary>
-        /// Gets the name of the configuration for the Salesforce WebHook receiver.
-        /// </summary>
-        public static string ConfigurationName => "SalesforceSoap";
-
-        /// <summary>
         /// Gets the name of the JSON property in a Salesforce WebHook request body containing a value somewhat
         /// analogous to an event name.
         /// </summary>
@@ -22,7 +17,7 @@ namespace Microsoft.AspNetCore.WebHooks
         /// <summary>
         /// Gets the name of the Salesforce WebHook receiver.
         /// </summary>
-        public static string ReceiverName => "sfsoap";
+        public static string ReceiverName => "salesforce";
 
         /// <summary>
         /// Gets the minimum length of the secret key configured for this receiver.

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/SalesforceWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/SalesforceWebHookAttribute.cs
@@ -17,12 +17,7 @@ namespace Microsoft.AspNetCore.WebHooks
     /// <see cref="System.Xml.Linq.XElement"/> or <see cref="SalesforceNotifications"/>.
     /// </para>
     /// <para>
-    /// The '<c>MS_WebHookReceiverSecret_SalesforceSoap</c>' configuration value contains Salesforce Organization IDs.
-    /// The Organizational IDs can be found at <see href="http://www.salesforce.com"/> under
-    /// <c>Setup | Company Profile | Company Information</c>.
-    /// </para>
-    /// <para>
-    /// An example Salesforce WebHook URI is '<c>https://&lt;host&gt;/api/webhooks/incoming/sfsoap/{id}</c>'.
+    /// An example Salesforce WebHook URI is '<c>https://&lt;host&gt;/api/webhooks/incoming/salesforce/{id}</c>'.
     /// See <see href="https://go.microsoft.com/fwlink/?linkid=838587"/> for additional details about Salesforce
     /// WebHook requests.
     /// </para>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/Extensions/SlackMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/Extensions/SlackMvcCoreBuilderExtensions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             SlackServiceCollectionSetup.AddSlackServices(builder.Services);
 
-            // While requests contain HTTP form data, responses are JSON.
+            // While requests contain HTML form URL-encoded data, responses are JSON.
             return builder
                 .AddJsonFormatters()
                 .AddWebHooks();

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/Filters/SlackVerifyTokenFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/Filters/SlackVerifyTokenFilter.cs
@@ -210,7 +210,7 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
         }
 
         /// <summary>
-        /// Reads the HTTP form data request entity body.
+        /// Reads the HTML form URL-encoded data request entity body.
         /// </summary>
         /// <param name="context">The <see cref="ResourceExecutingContext"/>.</param>
         /// <returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Properties/Resources.Designer.cs
@@ -205,7 +205,7 @@ namespace Microsoft.AspNetCore.WebHooks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The WebHook request must contain an entity body formatted as HTTP Post Form Data..
+        ///   Looks up a localized string similar to The WebHook request must contain an entity body formatted as HTML form URL-encoded data..
         /// </summary>
         internal static string VerifyBody_NoFormData {
             get {

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Properties/Resources.resx
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Properties/Resources.resx
@@ -166,7 +166,7 @@
     <value>Could not find a valid configuration for the '{0}' WebHook receiver. Please configure secret keys for this receiver.</value>
   </data>
   <data name="VerifyBody_NoFormData" xml:space="preserve">
-    <value>The WebHook request must contain an entity body formatted as HTTP Post Form Data.</value>
+    <value>The WebHook request must contain an entity body formatted as HTML form URL-encoded data.</value>
   </data>
   <data name="VerifyBody_NoJson" xml:space="preserve">
     <value>The WebHook request must contain an entity body formatted as JSON.</value>

--- a/test/Microsoft.AspNet.WebHooks.Receivers.MailChimp.Test/WebHooks/MailChimpWebHookReceiverTests.cs
+++ b/test/Microsoft.AspNet.WebHooks.Receivers.MailChimp.Test/WebHooks/MailChimpWebHookReceiverTests.cs
@@ -46,11 +46,11 @@ namespace Microsoft.AspNet.WebHooks
         {
             // Arrange
             IWebHookReceiver rec = new MailChimpWebHookReceiver();
-            string expected = "mailchimp";
+            var expected = "mailchimp";
 
             // Act
-            string actual1 = rec.Name;
-            string actual2 = MailChimpWebHookReceiver.ReceiverName;
+            var actual1 = rec.Name;
+            var actual2 = MailChimpWebHookReceiver.ReceiverName;
 
             // Assert
             Assert.Equal(expected, actual1);
@@ -65,10 +65,10 @@ namespace Microsoft.AspNet.WebHooks
             _postRequest.RequestUri = new Uri("http://some.no.ssl.host");
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The WebHook receiver 'MailChimpWebHookReceiverProxy' requires HTTPS in order to be secure. Please register a WebHook URI of type 'https'.", error.Message);
             ReceiverMock.Protected()
                 .Verify<Task<HttpResponseMessage>>("ExecuteWebHookAsync", Times.Never(), TestId, RequestContext, _postRequest, ItExpr.IsAny<IEnumerable<string>>(), ItExpr.IsAny<object>());
@@ -83,10 +83,10 @@ namespace Microsoft.AspNet.WebHooks
             _postRequest.RequestUri = new Uri("https://some.no.ssl.host?" + query);
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The WebHook verification request must contain a 'code' query parameter.", error.Message);
             ReceiverMock.Protected()
                 .Verify<Task<HttpResponseMessage>>("ExecuteWebHookAsync", Times.Never(), TestId, RequestContext, _postRequest, ItExpr.IsAny<IEnumerable<string>>(), ItExpr.IsAny<object>());
@@ -100,10 +100,10 @@ namespace Microsoft.AspNet.WebHooks
             _postRequest.RequestUri = new Uri("https://some.no.ssl.host?code=invalid");
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The 'code' query parameter provided in the HTTP request did not match the expected value.", error.Message);
             ReceiverMock.Protected()
                 .Verify<Task<HttpResponseMessage>>("ExecuteWebHookAsync", Times.Never(), TestId, RequestContext, _postRequest, ItExpr.IsAny<IEnumerable<string>>(), ItExpr.IsAny<object>());
@@ -117,11 +117,11 @@ namespace Microsoft.AspNet.WebHooks
             _postRequest.Content = new StringContent("{ }", Encoding.UTF8, "application/json");
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
-            Assert.Equal("The WebHook request must contain an entity body formatted as HTML Form Data.", error.Message);
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            Assert.Equal("The WebHook request must contain an entity body formatted as HTML form URL-encoded data.", error.Message);
             ReceiverMock.Protected()
                 .Verify<Task<HttpResponseMessage>>("ExecuteWebHookAsync", Times.Never(), TestId, RequestContext, _postRequest, ItExpr.IsAny<IEnumerable<string>>(), ItExpr.IsAny<object>());
         }
@@ -134,10 +134,10 @@ namespace Microsoft.AspNet.WebHooks
             _postRequest.Content = new StringContent("k=v", Encoding.UTF8, "application/x-www-form-urlencoded");
 
             // Act
-            HttpResponseMessage actual = await ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest);
+            var actual = await ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest);
 
             // Assert
-            HttpError error = await actual.Content.ReadAsAsync<HttpError>();
+            var error = await actual.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The HTTP request body did not contain a required 'type' property.", error.Message);
             ReceiverMock.Protected()
                 .Verify<Task<HttpResponseMessage>>("ExecuteWebHookAsync", Times.Never(), TestId, RequestContext, _postRequest, ItExpr.IsAny<IEnumerable<string>>(), ItExpr.IsAny<object>());
@@ -149,7 +149,7 @@ namespace Microsoft.AspNet.WebHooks
         {
             // Arrange
             Initialize(GetConfigValue(id, TestSecret));
-            List<string> actions = new List<string> { "hello" };
+            var actions = new List<string> { "hello" };
             ReceiverMock.Protected()
                 .Setup<Task<HttpResponseMessage>>("ExecuteWebHookAsync", id, RequestContext, _postRequest, actions, ItExpr.IsAny<object>())
                 .ReturnsAsync(new HttpResponseMessage())
@@ -170,10 +170,10 @@ namespace Microsoft.AspNet.WebHooks
             _getRequest.RequestUri = new Uri("http://some.no.ssl.host");
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _getRequest));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _getRequest));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The WebHook receiver 'MailChimpWebHookReceiverProxy' requires HTTPS in order to be secure. Please register a WebHook URI of type 'https'.", error.Message);
             ReceiverMock.Protected()
                 .Verify<Task<HttpResponseMessage>>("ExecuteWebHookAsync", Times.Never(), TestId, RequestContext, _getRequest, ItExpr.IsAny<IEnumerable<string>>(), ItExpr.IsAny<object>());
@@ -188,10 +188,10 @@ namespace Microsoft.AspNet.WebHooks
             _getRequest.RequestUri = new Uri("https://some.no.ssl.host?" + query);
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _getRequest));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _getRequest));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The WebHook verification request must contain a 'code' query parameter.", error.Message);
             ReceiverMock.Protected()
                 .Verify<Task<HttpResponseMessage>>("ExecuteWebHookAsync", Times.Never(), TestId, RequestContext, _getRequest, ItExpr.IsAny<IEnumerable<string>>(), ItExpr.IsAny<object>());
@@ -205,10 +205,10 @@ namespace Microsoft.AspNet.WebHooks
             _getRequest.RequestUri = new Uri("https://some.no.ssl.host?code=invalid");
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _getRequest));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _getRequest));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The 'code' query parameter provided in the HTTP request did not match the expected value.", error.Message);
             ReceiverMock.Protected()
                 .Verify<Task<HttpResponseMessage>>("ExecuteWebHookAsync", Times.Never(), TestId, RequestContext, _getRequest, ItExpr.IsAny<IEnumerable<string>>(), ItExpr.IsAny<object>());
@@ -222,7 +222,7 @@ namespace Microsoft.AspNet.WebHooks
             Initialize(GetConfigValue(id, TestSecret));
 
             // Act
-            HttpResponseMessage actual = await ReceiverMock.Object.ReceiveAsync(id, RequestContext, _getRequest);
+            var actual = await ReceiverMock.Object.ReceiveAsync(id, RequestContext, _getRequest);
 
             // Assert
             Assert.Equal(actual.StatusCode, HttpStatusCode.OK);
@@ -239,11 +239,11 @@ namespace Microsoft.AspNet.WebHooks
         {
             // Arrange
             Initialize(TestSecret);
-            HttpRequestMessage req = new HttpRequestMessage { Method = new HttpMethod(method) };
+            var req = new HttpRequestMessage { Method = new HttpMethod(method) };
             req.SetRequestContext(RequestContext);
 
             // Act
-            HttpResponseMessage actual = await ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, req);
+            var actual = await ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, req);
 
             // Assert
             Assert.Equal(HttpStatusCode.MethodNotAllowed, actual.StatusCode);

--- a/test/Microsoft.AspNet.WebHooks.Receivers.Slack.Test/WebHooks/SlackWebHookReceiverTests.cs
+++ b/test/Microsoft.AspNet.WebHooks.Receivers.Slack.Test/WebHooks/SlackWebHookReceiverTests.cs
@@ -49,11 +49,11 @@ namespace Microsoft.AspNet.WebHooks
         {
             // Arrange
             IWebHookReceiver rec = new SlackWebHookReceiver();
-            string expected = "slack";
+            var expected = "slack";
 
             // Act
-            string actual1 = rec.Name;
-            string actual2 = SlackWebHookReceiver.ReceiverName;
+            var actual1 = rec.Name;
+            var actual2 = SlackWebHookReceiver.ReceiverName;
 
             // Assert
             Assert.Equal(expected, actual1);
@@ -65,7 +65,7 @@ namespace Microsoft.AspNet.WebHooks
         public void GetSubtext_GetsCorrectText(string trigger, string text, string expected)
         {
             // Act
-            string actual = SlackWebHookReceiver.GetSubtext(trigger, text);
+            var actual = SlackWebHookReceiver.GetSubtext(trigger, text);
 
             // Assert
             Assert.Equal(expected, actual);
@@ -79,10 +79,10 @@ namespace Microsoft.AspNet.WebHooks
             _postRequest.RequestUri = new Uri("http://some.no.ssl.host");
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The WebHook receiver 'SlackWebHookReceiverProxy' requires HTTPS in order to be secure. Please register a WebHook URI of type 'https'.", error.Message);
             ReceiverMock.Protected()
                 .Verify<Task<HttpResponseMessage>>("ExecuteWebHookAsync", Times.Never(), TestId, RequestContext, _postRequest, ItExpr.IsAny<IEnumerable<string>>(), ItExpr.IsAny<object>());
@@ -96,11 +96,11 @@ namespace Microsoft.AspNet.WebHooks
             _postRequest.Content = new StringContent("{ }", Encoding.UTF8, "application/json");
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
-            Assert.Equal("The WebHook request must contain an entity body formatted as HTML Form Data.", error.Message);
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            Assert.Equal("The WebHook request must contain an entity body formatted as HTML form URL-encoded data.", error.Message);
             ReceiverMock.Protected()
                 .Verify<Task<HttpResponseMessage>>("ExecuteWebHookAsync", Times.Never(), TestId, RequestContext, _postRequest, ItExpr.IsAny<IEnumerable<string>>(), ItExpr.IsAny<object>());
         }
@@ -113,10 +113,10 @@ namespace Microsoft.AspNet.WebHooks
             _postRequest.Content = new StringContent("token=invalid", Encoding.UTF8, "application/x-www-form-urlencoded");
 
             // Act
-            HttpResponseMessage actual = await ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest);
+            var actual = await ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest);
 
             // Assert
-            HttpError error = await actual.Content.ReadAsAsync<HttpError>();
+            var error = await actual.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The 'token' parameter provided in the HTTP request did not match the expected value.", error.Message);
             ReceiverMock.Protected()
                 .Verify<Task<HttpResponseMessage>>("ExecuteWebHookAsync", Times.Never(), TestId, RequestContext, _postRequest, ItExpr.IsAny<IEnumerable<string>>(), ItExpr.IsAny<object>());
@@ -130,10 +130,10 @@ namespace Microsoft.AspNet.WebHooks
             _postRequest.Content = new StringContent("token=" + TestSecret, Encoding.UTF8, "application/x-www-form-urlencoded");
 
             // Act
-            HttpResponseMessage actual = await ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest);
+            var actual = await ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest);
 
             // Assert
-            HttpError error = await actual.Content.ReadAsAsync<HttpError>();
+            var error = await actual.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The HTTP request body did not contain a required 'command' property indicating a slash command or contained an empty 'trigger_word' parameter indicating an outgoing WebHook.", error.Message);
             ReceiverMock.Protected()
                 .Verify<Task<HttpResponseMessage>>("ExecuteWebHookAsync", Times.Never(), TestId, RequestContext, _postRequest, ItExpr.IsAny<IEnumerable<string>>(), ItExpr.IsAny<object>());
@@ -145,7 +145,7 @@ namespace Microsoft.AspNet.WebHooks
         {
             // Arrange
             Initialize(GetConfigValue(id, TestSecret));
-            List<string> actions = new List<string> { "trigger: hello!" };
+            var actions = new List<string> { "trigger: hello!" };
             ReceiverMock.Protected()
                 .Setup<Task<HttpResponseMessage>>("ExecuteWebHookAsync", id, RequestContext, _postRequest, actions, ItExpr.IsAny<object>())
                 .ReturnsAsync(new HttpResponseMessage())
@@ -166,7 +166,7 @@ namespace Microsoft.AspNet.WebHooks
             Initialize(GetConfigValue(id, TestSecret));
             _postRequest.Content = new StringContent(TestSlashContent, Encoding.UTF8, "application/x-www-form-urlencoded");
 
-            List<string> actions = new List<string> { "hello!" };
+            var actions = new List<string> { "hello!" };
             ReceiverMock.Protected()
                 .Setup<Task<HttpResponseMessage>>("ExecuteWebHookAsync", id, RequestContext, _postRequest, actions, ItExpr.IsAny<object>())
                 .ReturnsAsync(new HttpResponseMessage())
@@ -189,11 +189,11 @@ namespace Microsoft.AspNet.WebHooks
         {
             // Arrange
             Initialize(TestSecret);
-            HttpRequestMessage req = new HttpRequestMessage { Method = new HttpMethod(method) };
+            var req = new HttpRequestMessage { Method = new HttpMethod(method) };
             req.SetRequestContext(RequestContext);
 
             // Act
-            HttpResponseMessage actual = await ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, req);
+            var actual = await ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, req);
 
             // Assert
             Assert.Equal(HttpStatusCode.MethodNotAllowed, actual.StatusCode);

--- a/test/Microsoft.AspNet.WebHooks.Receivers.Test/WebHooks/WebHookReceiverTests.cs
+++ b/test/Microsoft.AspNet.WebHooks.Receivers.Test/WebHooks/WebHookReceiverTests.cs
@@ -3,14 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web.Http;
 using System.Web.Http.Controllers;
-using System.Xml.Linq;
 using Microsoft.AspNet.WebHooks.Config;
 using Microsoft.AspNet.WebHooks.Diagnostics;
 using Microsoft.AspNet.WebHooks.Mocks;
@@ -149,10 +147,10 @@ namespace Microsoft.AspNet.WebHooks
             _request.RequestUri = new Uri("http://some.no.ssl.host");
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.EnsureValidCode(_request, TestId));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.EnsureValidCode(_request, TestId));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The WebHook receiver 'WebHookReceiverMock' requires HTTPS in order to be secure. Please register a WebHook URI of type 'https'.", error.Message);
         }
 
@@ -165,10 +163,10 @@ namespace Microsoft.AspNet.WebHooks
             _request.RequestUri = new Uri("https://some.no.ssl.host?" + query);
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.EnsureValidCode(_request, TestId));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.EnsureValidCode(_request, TestId));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The WebHook verification request must contain a 'code' query parameter.", error.Message);
         }
 
@@ -181,10 +179,10 @@ namespace Microsoft.AspNet.WebHooks
             _request.RequestUri = new Uri("https://some.no.ssl.host?code=invalid");
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.EnsureValidCode(_request, id));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.EnsureValidCode(_request, id));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The 'code' query parameter provided in the HTTP request did not match the expected value.", error.Message);
         }
 
@@ -211,11 +209,11 @@ namespace Microsoft.AspNet.WebHooks
             _request.RequestUri = new Uri(address);
 
             // Act
-            HttpResponseException ex = Assert.Throws<HttpResponseException>(() => _receiverMock.EnsureSecureConnection(_request));
+            var ex = Assert.Throws<HttpResponseException>(() => _receiverMock.EnsureSecureConnection(_request));
 
             // Assert
-            string expected = string.Format("The WebHook receiver 'WebHookReceiverMock' requires HTTPS in order to be secure. Please register a WebHook URI of type 'https'.");
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var expected = string.Format("The WebHook receiver 'WebHookReceiverMock' requires HTTPS in order to be secure. Please register a WebHook URI of type 'https'.");
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal(expected, error.Message);
         }
 
@@ -259,11 +257,11 @@ namespace Microsoft.AspNet.WebHooks
             Initialize(secret);
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.GetReceiverConfig(_request, _receiverMock.Name, TestId, minLength, maxLength));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.GetReceiverConfig(_request, _receiverMock.Name, TestId, minLength, maxLength));
 
             // Assert
-            string expected = string.Format("Could not find a valid configuration for WebHook receiver 'MockReceiver' and instance '{0}'. The setting must be set to a value between {1} and {2} characters long.", TestId, minLength, maxLength);
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var expected = string.Format("Could not find a valid configuration for WebHook receiver 'MockReceiver' and instance '{0}'. The setting must be set to a value between {1} and {2} characters long.", TestId, minLength, maxLength);
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal(expected, error.Message);
         }
 
@@ -275,7 +273,7 @@ namespace Microsoft.AspNet.WebHooks
             Initialize(name, id, secret);
 
             // Act
-            string actual = await _receiverMock.GetReceiverConfig(_request, name, id, minLength, maxLength);
+            var actual = await _receiverMock.GetReceiverConfig(_request, name, id, minLength, maxLength);
 
             // Assert
             Assert.Equal(secret, actual);
@@ -289,18 +287,18 @@ namespace Microsoft.AspNet.WebHooks
         {
             // Arrange
             Initialize(TestSecret);
-            string name = "signature";
-            for (int cnt = 0; cnt < headers; cnt++)
+            var name = "signature";
+            for (var cnt = 0; cnt < headers; cnt++)
             {
                 _request.Headers.Add(name, "value");
             }
 
             // Act
-            HttpResponseException ex = Assert.Throws<HttpResponseException>(() => _receiverMock.GetRequestHeader(_request, name));
+            var ex = Assert.Throws<HttpResponseException>(() => _receiverMock.GetRequestHeader(_request, name));
 
             // Assert
-            string expected = string.Format("Expecting exactly one 'signature' header field in the WebHook request but found {0}. Please ensure that the request contains exactly one 'signature' header field.", headers);
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var expected = string.Format("Expecting exactly one 'signature' header field in the WebHook request but found {0}. Please ensure that the request contains exactly one 'signature' header field.", headers);
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal(expected, error.Message);
         }
 
@@ -309,12 +307,12 @@ namespace Microsoft.AspNet.WebHooks
         {
             // Arrange
             Initialize(TestSecret);
-            string expected = "value";
-            string name = "signature";
+            var expected = "value";
+            var name = "signature";
             _request.Headers.Add(name, expected);
 
             // Act
-            string actual = _receiverMock.GetRequestHeader(_request, name);
+            var actual = _receiverMock.GetRequestHeader(_request, name);
 
             // Assert
             Assert.Equal(expected, actual);
@@ -327,10 +325,10 @@ namespace Microsoft.AspNet.WebHooks
             Initialize(TestSecret);
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsJsonAsync(_request));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsJsonAsync(_request));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The WebHook request entity body cannot be empty.", error.Message);
         }
 
@@ -342,10 +340,10 @@ namespace Microsoft.AspNet.WebHooks
             _request.Content = new StringContent("Hello World", Encoding.UTF8, "text/plain");
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsJsonAsync(_request));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsJsonAsync(_request));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The WebHook request must contain an entity body formatted as JSON.", error.Message);
         }
 
@@ -357,10 +355,10 @@ namespace Microsoft.AspNet.WebHooks
             _request.Content = new StringContent("I n v a l i d  J S O N", Encoding.UTF8, "application/json");
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsJsonAsync(_request));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsJsonAsync(_request));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The WebHook request contained invalid JSON: 'Error parsing positive infinity value. Path '', line 0, position 0.'.", error.Message);
         }
 
@@ -368,13 +366,13 @@ namespace Microsoft.AspNet.WebHooks
         public async Task ReadAsJsonAsync_Handles_UtcDateTime()
         {
             // Arrange
-            DateTime expectedDateTime = DateTime.Parse("2015-09-26T04:26:55.6393049Z").ToUniversalTime();
+            var expectedDateTime = DateTime.Parse("2015-09-26T04:26:55.6393049Z").ToUniversalTime();
             Initialize(TestSecret);
             _request.Content = new StringContent("{ \"datetime\": \"2015-09-26T04:26:55.6393049Z\" }", Encoding.UTF8, "application/json");
 
             // Act
-            JObject actual = await _receiverMock.ReadAsJsonAsync(_request);
-            DateTime actualDateTime = actual["datetime"].ToObject<DateTime>();
+            var actual = await _receiverMock.ReadAsJsonAsync(_request);
+            var actualDateTime = actual["datetime"].ToObject<DateTime>();
 
             // Assert
             Assert.Equal(expectedDateTime, actualDateTime);
@@ -388,7 +386,7 @@ namespace Microsoft.AspNet.WebHooks
             _request.Content = new StringContent("{ \"k\": \"v\" }", Encoding.UTF8, "application/json");
 
             // Act
-            JObject actual = await _receiverMock.ReadAsJsonAsync(_request);
+            var actual = await _receiverMock.ReadAsJsonAsync(_request);
 
             // Assert
             Assert.Equal("v", actual["k"]);
@@ -401,10 +399,10 @@ namespace Microsoft.AspNet.WebHooks
             Initialize(TestSecret);
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsJsonTokenAsync(_request));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsJsonTokenAsync(_request));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The WebHook request entity body cannot be empty.", error.Message);
         }
 
@@ -416,10 +414,10 @@ namespace Microsoft.AspNet.WebHooks
             _request.Content = new StringContent("Hello World", Encoding.UTF8, "text/plain");
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsJsonTokenAsync(_request));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsJsonTokenAsync(_request));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The WebHook request must contain an entity body formatted as JSON.", error.Message);
         }
 
@@ -431,10 +429,10 @@ namespace Microsoft.AspNet.WebHooks
             _request.Content = new StringContent("I n v a l i d  J S O N", Encoding.UTF8, "application/json");
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsJsonTokenAsync(_request));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsJsonTokenAsync(_request));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The WebHook request contained invalid JSON: 'Error parsing positive infinity value. Path '', line 0, position 0.'.", error.Message);
         }
 
@@ -442,13 +440,13 @@ namespace Microsoft.AspNet.WebHooks
         public async Task ReadAsJsonTokenAsync_Handles_UtcDateTime()
         {
             // Arrange
-            DateTime expectedDateTime = DateTime.Parse("2015-09-26T04:26:55.6393049Z").ToUniversalTime();
+            var expectedDateTime = DateTime.Parse("2015-09-26T04:26:55.6393049Z").ToUniversalTime();
             Initialize(TestSecret);
             _request.Content = new StringContent("{ \"datetime\": \"2015-09-26T04:26:55.6393049Z\" }", Encoding.UTF8, "application/json");
 
             // Act
-            JToken actual = await _receiverMock.ReadAsJsonTokenAsync(_request);
-            DateTime actualDateTime = actual["datetime"].ToObject<DateTime>();
+            var actual = await _receiverMock.ReadAsJsonTokenAsync(_request);
+            var actualDateTime = actual["datetime"].ToObject<DateTime>();
 
             // Assert
             Assert.Equal(expectedDateTime, actualDateTime);
@@ -463,7 +461,7 @@ namespace Microsoft.AspNet.WebHooks
             _request.Content = new StringContent(content, Encoding.UTF8, "application/json");
 
             // Act
-            JToken actual = await _receiverMock.ReadAsJsonTokenAsync(_request);
+            var actual = await _receiverMock.ReadAsJsonTokenAsync(_request);
 
             // Assert
             Assert.IsType(expectedType, actual);
@@ -477,10 +475,10 @@ namespace Microsoft.AspNet.WebHooks
             Initialize(TestSecret);
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsXmlAsync(_request));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsXmlAsync(_request));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The WebHook request entity body cannot be empty.", error.Message);
         }
 
@@ -492,10 +490,10 @@ namespace Microsoft.AspNet.WebHooks
             _request.Content = new StringContent("Hello World", Encoding.UTF8, "text/plain");
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsXmlAsync(_request));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsXmlAsync(_request));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The WebHook request must contain an entity body formatted as XML.", error.Message);
         }
 
@@ -507,10 +505,10 @@ namespace Microsoft.AspNet.WebHooks
             _request.Content = new StringContent("I n v a l i d  X M L", Encoding.UTF8, "application/xml");
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsXmlAsync(_request));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsXmlAsync(_request));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The WebHook request contained invalid XML: 'There was an error deserializing the object of type System.Xml.Linq.XElement. The data at the root level is invalid. Line 1, position 1.'.", error.Message);
         }
 
@@ -522,7 +520,7 @@ namespace Microsoft.AspNet.WebHooks
             _request.Content = new StringContent("<root><k>v</k></root>", Encoding.UTF8, "application/xml");
 
             // Act
-            XElement actual = await _receiverMock.ReadAsXmlAsync(_request);
+            var actual = await _receiverMock.ReadAsXmlAsync(_request);
 
             // Assert
             Assert.Equal("v", actual.Element("k").Value);
@@ -535,10 +533,10 @@ namespace Microsoft.AspNet.WebHooks
             Initialize(TestSecret);
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsFormDataAsync(_request));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsFormDataAsync(_request));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The WebHook request entity body cannot be empty.", error.Message);
         }
 
@@ -550,11 +548,11 @@ namespace Microsoft.AspNet.WebHooks
             _request.Content = new StringContent("Hello World", Encoding.UTF8, "text/plain");
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsFormDataAsync(_request));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => _receiverMock.ReadAsFormDataAsync(_request));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
-            Assert.Equal("The WebHook request must contain an entity body formatted as HTML Form Data.", error.Message);
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            Assert.Equal("The WebHook request must contain an entity body formatted as HTML form URL-encoded data.", error.Message);
         }
 
         [Fact]
@@ -565,7 +563,7 @@ namespace Microsoft.AspNet.WebHooks
             _request.Content = new StringContent("k=v", Encoding.UTF8, "application/x-www-form-urlencoded");
 
             // Act
-            NameValueCollection actual = await _receiverMock.ReadAsFormDataAsync(_request);
+            var actual = await _receiverMock.ReadAsFormDataAsync(_request);
 
             // Assert
             Assert.Equal("v", actual["k"]);
@@ -578,11 +576,11 @@ namespace Microsoft.AspNet.WebHooks
             Initialize(TestSecret);
 
             // Act
-            HttpResponseMessage actual = _receiverMock.CreateBadMethodResponse(_request);
+            var actual = _receiverMock.CreateBadMethodResponse(_request);
 
             // Assert
             Assert.Equal(HttpStatusCode.MethodNotAllowed, actual.StatusCode);
-            HttpError error = await actual.Content.ReadAsAsync<HttpError>();
+            var error = await actual.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The HTTP 'GET' method is not supported by the 'WebHookReceiverMock' WebHook receiver.", error.Message);
         }
 
@@ -593,11 +591,11 @@ namespace Microsoft.AspNet.WebHooks
             Initialize(TestSecret);
 
             // Act
-            HttpResponseMessage actual = _receiverMock.CreateBadSignatureResponse(_request, "Header");
+            var actual = _receiverMock.CreateBadSignatureResponse(_request, "Header");
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, actual.StatusCode);
-            HttpError error = await actual.Content.ReadAsAsync<HttpError>();
+            var error = await actual.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The WebHook signature provided by the 'Header' header field does not match the value expected by the 'WebHookReceiverMock' receiver. WebHook request is invalid.", error.Message);
         }
 
@@ -605,7 +603,7 @@ namespace Microsoft.AspNet.WebHooks
         public async Task ExecuteWebHookAsync_StopsOnFirstResponse()
         {
             // Arrange
-            KeyValuePair<Type, object>[] handlers = new KeyValuePair<Type, object>[]
+            var handlers = new KeyValuePair<Type, object>[]
             {
                 new KeyValuePair<Type, object>(typeof(IWebHookHandler), new TestHandler { Order = 10, }),
                 new KeyValuePair<Type, object>(typeof(IWebHookHandler), new TestHandler { Order = 20, }),
@@ -613,10 +611,10 @@ namespace Microsoft.AspNet.WebHooks
                 new KeyValuePair<Type, object>(typeof(IWebHookHandler), new TestHandler { Order = 40, }),
             };
             Initialize(TestSecret, handlers);
-            object data = new object();
+            var data = new object();
 
             // Act
-            HttpResponseMessage actual = await _receiverMock.ExecuteWebHookAsync(TestId, _context, _request, new[] { "action" }, data);
+            var actual = await _receiverMock.ExecuteWebHookAsync(TestId, _context, _request, new[] { "action" }, data);
 
             // Assert
             Assert.Equal("Order: 30", actual.ReasonPhrase);
@@ -630,7 +628,7 @@ namespace Microsoft.AspNet.WebHooks
         public async Task ExecuteWebHookAsync_FindsMatchingHandlers()
         {
             // Arrange
-            KeyValuePair<Type, object>[] handlers = new KeyValuePair<Type, object>[]
+            var handlers = new KeyValuePair<Type, object>[]
             {
                 new KeyValuePair<Type, object>(typeof(IWebHookHandler), new TestHandler { Order = 10, Receiver = "other" }),
                 new KeyValuePair<Type, object>(typeof(IWebHookHandler), new TestHandler { Order = 20, Receiver = "MockReceiver" }),
@@ -639,10 +637,10 @@ namespace Microsoft.AspNet.WebHooks
                 new KeyValuePair<Type, object>(typeof(IWebHookHandler), new TestHandler { Order = 50, Receiver = "something" }),
             };
             Initialize(TestSecret, handlers);
-            object data = new object();
+            var data = new object();
 
             // Act
-            HttpResponseMessage actual = await _receiverMock.ExecuteWebHookAsync(TestId, _context, _request, new[] { "action" }, data);
+            var actual = await _receiverMock.ExecuteWebHookAsync(TestId, _context, _request, new[] { "action" }, data);
 
             // Assert
             Assert.Equal("OK", actual.ReasonPhrase);
@@ -658,18 +656,18 @@ namespace Microsoft.AspNet.WebHooks
         {
             // Arrange
             WebHookHandlerContext actual = null;
-            Mock<IWebHookHandler> handlerMock = new Mock<IWebHookHandler>();
+            var handlerMock = new Mock<IWebHookHandler>();
             handlerMock.Setup<Task>(h => h.ExecuteAsync(WebHookReceiverMock.ReceiverName, It.IsAny<WebHookHandlerContext>()))
                 .Callback<string, WebHookHandlerContext>((rec, con) => actual = con)
                 .Returns(Task.FromResult(true))
                 .Verifiable();
 
-            KeyValuePair<Type, object>[] handlers = new KeyValuePair<Type, object>[]
+            var handlers = new KeyValuePair<Type, object>[]
             {
                 new KeyValuePair<Type, object>(typeof(IWebHookHandler), handlerMock.Object),
             };
             Initialize(TestSecret, handlers);
-            object data = new object();
+            var data = new object();
             IEnumerable<string> actions = new[] { "action" };
 
             // Act
@@ -692,7 +690,7 @@ namespace Microsoft.AspNet.WebHooks
             Initialize(TestSecret);
 
             // Act
-            bool actual = WebHookReceiver.SecretEqual(inputA, inputB);
+            var actual = WebHookReceiver.SecretEqual(inputA, inputB);
 
             // Assert
             Assert.Equal(expected, actual);
@@ -706,7 +704,7 @@ namespace Microsoft.AspNet.WebHooks
             Initialize(TestSecret);
 
             // Act
-            bool actual = WebHookReceiver.SecretEqual(inputA, inputB);
+            var actual = WebHookReceiver.SecretEqual(inputA, inputB);
 
             // Assert
             Assert.Equal(expected, actual);
@@ -720,12 +718,14 @@ namespace Microsoft.AspNet.WebHooks
         public void Initialize(string name, string id, string config, params KeyValuePair<Type, object>[] dependencies)
         {
             _logger = new Mock<ILogger>().Object;
-            _settings = new SettingsDictionary();
-            _settings[SecretPrefix + name] = GetConfigValue(id, config);
+            _settings = new SettingsDictionary
+            {
+                [SecretPrefix + name] = GetConfigValue(id, config)
+            };
 
             _config = new WebHookReceiverConfig(_settings, _logger);
 
-            List<KeyValuePair<Type, object>> deps = new List<KeyValuePair<Type, object>>()
+            var deps = new List<KeyValuePair<Type, object>>()
             {
                 new KeyValuePair<Type, object>(typeof(IWebHookReceiverConfig), _config),
                 new KeyValuePair<Type, object>(typeof(SettingsDictionary), _settings)
@@ -761,8 +761,10 @@ namespace Microsoft.AspNet.WebHooks
                 IsCalled = true;
                 if (SetResponse)
                 {
-                    context.Response = new HttpResponseMessage();
-                    context.Response.ReasonPhrase = "Order: " + Order;
+                    context.Response = new HttpResponseMessage
+                    {
+                        ReasonPhrase = "Order: " + Order
+                    };
                 }
                 return Task.FromResult(true);
             }

--- a/test/Microsoft.AspNet.WebHooks.Receivers.WordPress.Test/WebHooks/WordPressWebHookReceiverTests.cs
+++ b/test/Microsoft.AspNet.WebHooks.Receivers.WordPress.Test/WebHooks/WordPressWebHookReceiverTests.cs
@@ -45,11 +45,11 @@ namespace Microsoft.AspNet.WebHooks
         {
             // Arrange
             IWebHookReceiver rec = new WordPressWebHookReceiver();
-            string expected = "wordpress";
+            var expected = "wordpress";
 
             // Act
-            string actual1 = rec.Name;
-            string actual2 = WordPressWebHookReceiver.ReceiverName;
+            var actual1 = rec.Name;
+            var actual2 = WordPressWebHookReceiver.ReceiverName;
 
             // Assert
             Assert.Equal(expected, actual1);
@@ -64,10 +64,10 @@ namespace Microsoft.AspNet.WebHooks
             _postRequest.RequestUri = new Uri("http://some.no.ssl.host");
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The WebHook receiver 'WordPressWebHookReceiverProxy' requires HTTPS in order to be secure. Please register a WebHook URI of type 'https'.", error.Message);
             ReceiverMock.Protected()
                 .Verify<Task<HttpResponseMessage>>("ExecuteWebHookAsync", Times.Never(), TestId, RequestContext, _postRequest, ItExpr.IsAny<IEnumerable<string>>(), ItExpr.IsAny<object>());
@@ -82,10 +82,10 @@ namespace Microsoft.AspNet.WebHooks
             _postRequest.RequestUri = new Uri("https://some.no.ssl.host?" + query);
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The WebHook verification request must contain a 'code' query parameter.", error.Message);
             ReceiverMock.Protected()
                 .Verify<Task<HttpResponseMessage>>("ExecuteWebHookAsync", Times.Never(), TestId, RequestContext, _postRequest, ItExpr.IsAny<IEnumerable<string>>(), ItExpr.IsAny<object>());
@@ -99,10 +99,10 @@ namespace Microsoft.AspNet.WebHooks
             _postRequest.RequestUri = new Uri("https://some.no.ssl.host?code=invalid");
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The 'code' query parameter provided in the HTTP request did not match the expected value.", error.Message);
             ReceiverMock.Protected()
                 .Verify<Task<HttpResponseMessage>>("ExecuteWebHookAsync", Times.Never(), TestId, RequestContext, _postRequest, ItExpr.IsAny<IEnumerable<string>>(), ItExpr.IsAny<object>());
@@ -116,11 +116,11 @@ namespace Microsoft.AspNet.WebHooks
             _postRequest.Content = new StringContent("{ }", Encoding.UTF8, "application/json");
 
             // Act
-            HttpResponseException ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest));
+            var ex = await Assert.ThrowsAsync<HttpResponseException>(() => ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest));
 
             // Assert
-            HttpError error = await ex.Response.Content.ReadAsAsync<HttpError>();
-            Assert.Equal("The WebHook request must contain an entity body formatted as HTML Form Data.", error.Message);
+            var error = await ex.Response.Content.ReadAsAsync<HttpError>();
+            Assert.Equal("The WebHook request must contain an entity body formatted as HTML form URL-encoded data.", error.Message);
             ReceiverMock.Protected()
                 .Verify<Task<HttpResponseMessage>>("ExecuteWebHookAsync", Times.Never(), TestId, RequestContext, _postRequest, ItExpr.IsAny<IEnumerable<string>>(), ItExpr.IsAny<object>());
         }
@@ -133,10 +133,10 @@ namespace Microsoft.AspNet.WebHooks
             _postRequest.Content = new StringContent("k=v", Encoding.UTF8, "application/x-www-form-urlencoded");
 
             // Act
-            HttpResponseMessage actual = await ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest);
+            var actual = await ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, _postRequest);
 
             // Assert
-            HttpError error = await actual.Content.ReadAsAsync<HttpError>();
+            var error = await actual.Content.ReadAsAsync<HttpError>();
             Assert.Equal("The HTTP request body did not contain a required 'hook' property.", error.Message);
             ReceiverMock.Protected()
                 .Verify<Task<HttpResponseMessage>>("ExecuteWebHookAsync", Times.Never(), TestId, RequestContext, _postRequest, ItExpr.IsAny<IEnumerable<string>>(), ItExpr.IsAny<object>());
@@ -148,7 +148,7 @@ namespace Microsoft.AspNet.WebHooks
         {
             // Arrange
             Initialize(GetConfigValue(id, TestSecret));
-            List<string> actions = new List<string> { "hello" };
+            var actions = new List<string> { "hello" };
             ReceiverMock.Protected()
                 .Setup<Task<HttpResponseMessage>>("ExecuteWebHookAsync", id, RequestContext, _postRequest, actions, ItExpr.IsAny<object>())
                 .ReturnsAsync(new HttpResponseMessage())
@@ -171,11 +171,11 @@ namespace Microsoft.AspNet.WebHooks
         {
             // Arrange
             Initialize(TestSecret);
-            HttpRequestMessage req = new HttpRequestMessage { Method = new HttpMethod(method) };
+            var req = new HttpRequestMessage { Method = new HttpMethod(method) };
             req.SetRequestContext(RequestContext);
 
             // Act
-            HttpResponseMessage actual = await ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, req);
+            var actual = await ReceiverMock.Object.ReceiveAsync(TestId, RequestContext, req);
 
             // Assert
             Assert.Equal(HttpStatusCode.MethodNotAllowed, actual.StatusCode);


### PR DESCRIPTION
- "Form Data" -> "form URL-encoded data"
  - #145
- rename Salesforce receiver and configuration in Core
  - #193
  - also lowercase Pusher reciever name in Core for consistency

nits: accept VS suggestions in changed files e.g. more `var`