### PR TITLE
Stop using `NameValueCollection` in ASP.NET Core WebHooks

### DIFF
--- a/WebHooks.sln
+++ b/WebHooks.sln
@@ -240,6 +240,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StripeCoreReceiver", "sampl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.WebHooks.Receivers.Stripe.Test", "test\Microsoft.AspNetCore.WebHooks.Receivers.Stripe.Test\Microsoft.AspNetCore.WebHooks.Receivers.Stripe.Test.csproj", "{79247F99-4829-4FB4-8412-0ECF39FF7E37}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.WebHooks.Receivers.Slack.Test", "test\Microsoft.AspNetCore.WebHooks.Receivers.Slack.Test\Microsoft.AspNetCore.WebHooks.Receivers.Slack.Test.csproj", "{DFD36032-179A-4C2E-A90B-0537A864969A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		CodeAnalysis|Any CPU = CodeAnalysis|Any CPU
@@ -835,6 +837,12 @@ Global
 		{79247F99-4829-4FB4-8412-0ECF39FF7E37}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{79247F99-4829-4FB4-8412-0ECF39FF7E37}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{79247F99-4829-4FB4-8412-0ECF39FF7E37}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DFD36032-179A-4C2E-A90B-0537A864969A}.CodeAnalysis|Any CPU.ActiveCfg = CodeAnalysis|Any CPU
+		{DFD36032-179A-4C2E-A90B-0537A864969A}.CodeAnalysis|Any CPU.Build.0 = CodeAnalysis|Any CPU
+		{DFD36032-179A-4C2E-A90B-0537A864969A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DFD36032-179A-4C2E-A90B-0537A864969A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DFD36032-179A-4C2E-A90B-0537A864969A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DFD36032-179A-4C2E-A90B-0537A864969A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -944,6 +952,7 @@ Global
 		{D3A8D951-D55A-414E-8A5D-F8A8AF1F61FA} = {5759F48E-0D9E-457F-A93D-40FBC422B0CE}
 		{693E5E07-5A05-4569-8373-369D4F918BEF} = {5759F48E-0D9E-457F-A93D-40FBC422B0CE}
 		{79247F99-4829-4FB4-8412-0ECF39FF7E37} = {554337F5-F56F-4F93-9AE7-78F9EBCECC20}
+		{DFD36032-179A-4C2E-A90B-0537A864969A} = {554337F5-F56F-4F93-9AE7-78F9EBCECC20}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {12CE6238-F847-4984-8622-1ED46072150A}

--- a/samples/SlackCoreReceiver/Controllers/SlackController.cs
+++ b/samples/SlackCoreReceiver/Controllers/SlackController.cs
@@ -47,13 +47,21 @@ namespace SlackCoreReceiver.Controllers
                 text,
                 subtext);
 
+            var slashCommand = SlackCommand.ParseActionWithValue(command);
+
+            // Ignore an error parsing the remainder of the command except to keep that action value together.
+            var actionValue = slashCommand.Value;
+            var actionValueName = "value";
+            var (parameters, error) = SlackCommand.ParseParameters(slashCommand.Value);
+            if (error == null)
+            {
+                actionValue = SlackCommand.GetNormalizedParameterString(parameters);
+                actionValueName = "parameters";
+            }
+
             // Create the response.
-            var slashCommand = SlackCommand.ParseActionWithParameters(command);
-            var reply = string.Format(
-                "Received slash command '{0}' with action '{1}' and value '{2}'",
-                command,
-                slashCommand.Key,
-                slashCommand.Value.ToString());
+            var reply = $"Received slash command '{command}' with action '{slashCommand.Key}' and {actionValueName} " +
+                $"'{actionValue}'.";
 
             // Slash responses can be augmented with attachments containing data, images, and more.
             var attachment = new SlackAttachment("Attachment Text", "Fallback description")

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/Microsoft.AspNetCore.WebHooks.Receivers.Slack.csproj
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/Microsoft.AspNetCore.WebHooks.Receivers.Slack.csproj
@@ -6,9 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Microsoft.AspNet.WebHooks.Receivers.Slack\WebHooks\ParameterCollection.cs">
-      <Link>ParameterCollection.cs</Link>
-    </Compile>
     <Compile Include="..\Microsoft.AspNet.WebHooks.Receivers.Slack\WebHooks\SlackAttachment.cs">
       <Link>SlackAttachment.cs</Link>
     </Compile>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/Properties/Resources.Designer.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNetCore.WebHooks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameter name cannot contain &apos;;&apos; characters: ({0})..
+        ///   Looks up a localized string similar to Parameter name cannot contain &apos;;&apos; characters. Unexpected escape sequence ({0}) discovered at position {1}..
         /// </summary>
         internal static string Command_NameInvalid {
             get {
@@ -79,11 +79,20 @@ namespace Microsoft.AspNetCore.WebHooks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameter name cannot be a quoted string: ({0})..
+        ///   Looks up a localized string similar to Parameter name cannot be a quoted string. Unexpected character ({0}) discovered at position {1}..
         /// </summary>
         internal static string Command_NameIsQuotedString {
             get {
                 return ResourceManager.GetString("Command_NameIsQuotedString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parameter value contains text after a quoted string. Unexpected character ({0}) discovered at position {1}..
+        /// </summary>
+        internal static string Command_ValueInvalid {
+            get {
+                return ResourceManager.GetString("Command_ValueInvalid", resourceCulture);
             }
         }
         

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/Properties/Resources.resx
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/Properties/Resources.resx
@@ -121,10 +121,13 @@
     <value>Unmatched quote ({0}) discovered at position {1}.</value>
   </data>
   <data name="Command_NameInvalid" xml:space="preserve">
-    <value>Parameter name cannot contain ';' characters: ({0}).</value>
+    <value>Parameter name cannot contain ';' characters. Unexpected escape sequence ({0}) discovered at position {1}.</value>
   </data>
   <data name="Command_NameIsQuotedString" xml:space="preserve">
-    <value>Parameter name cannot be a quoted string: ({0}).</value>
+    <value>Parameter name cannot be a quoted string. Unexpected character ({0}) discovered at position {1}.</value>
+  </data>
+  <data name="Command_ValueInvalid" xml:space="preserve">
+    <value>Parameter value contains text after a quoted string. Unexpected character ({0}) discovered at position {1}.</value>
   </data>
   <data name="VerifyToken_BadValue" xml:space="preserve">
     <value>The '{0}' value provided in the HTTP request body did not match the expected value.</value>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/SlackCommand.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/SlackCommand.cs
@@ -3,12 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Globalization;
-using System.Linq;
 using System.Text;
 using Microsoft.AspNetCore.WebHooks.Properties;
 using Microsoft.AspNetCore.WebHooks.Utilities;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.WebHooks
 {
@@ -19,9 +18,7 @@ namespace Microsoft.AspNetCore.WebHooks
     /// </summary>
     public static class SlackCommand
     {
-        private static readonly char[] EqualSeparator = new[] { '=' };
         private static readonly char[] LwsSeparator = new[] { ' ' };
-        private static readonly char[] ParameterSeparator = new[] { ';' };
 
         /// <summary>
         /// Parses the 'text' of a slash command or 'subtext' of an outgoing WebHook of the form '<c>action value</c>'.
@@ -32,29 +29,35 @@ namespace Microsoft.AspNetCore.WebHooks
         /// 'query' is the action and 'what's the weather?' is the value.
         /// </example>
         /// <param name="text">The 'text' of a slash command or 'subtext' of an outgoing WebHook.</param>
-        public static KeyValuePair<string, string> ParseActionWithValue(string text)
+        /// <returns>
+        /// A <see cref="KeyValuePair{TKey, TValue}"/> mapping the action to its value. Both properties of the
+        /// <see cref="KeyValuePair{TKey, TValue}"/> will be <see cref="StringSegment.Empty"/> when the
+        /// <paramref name="text"/> does not contain an action. The <see cref="KeyValuePair{TKey, TValue}.Value"/> will
+        /// be <see cref="StringSegment.Empty"/> when the <paramref name="text"/> contains no interior spaces i.e. the
+        /// action has no value.
+        /// </returns>
+        public static KeyValuePair<StringSegment, StringSegment> ParseActionWithValue(string text)
         {
             if (string.IsNullOrEmpty(text))
             {
-                return new KeyValuePair<string, string>(string.Empty, string.Empty);
+                return new KeyValuePair<StringSegment, StringSegment>(StringSegment.Empty, StringSegment.Empty);
             }
 
-            var values = new TrimmingTokenizer(text, LwsSeparator, 2).ToArray();
-            if (values.Length == 0)
+            var values = new TrimmingTokenizer(text, LwsSeparator, maxCount: 2);
+            var enumerator = values.GetEnumerator();
+            if (!enumerator.MoveNext())
             {
-                return new KeyValuePair<string, string>(string.Empty, string.Empty);
+                return new KeyValuePair<StringSegment, StringSegment>(StringSegment.Empty, StringSegment.Empty);
             }
 
-            var result = new KeyValuePair<string, string>(
-                values[0].Value,
-                values.Length > 1 ? values[1].Value : string.Empty);
+            var action = enumerator.Current;
+            var value = enumerator.MoveNext() ? enumerator.Current : StringSegment.Empty;
 
-            return result;
+            return new KeyValuePair<StringSegment, StringSegment>(action, value);
         }
 
-        // ??? Should we continue to use NameValueCollection here and as the base for ParameterCollection?
         /// <summary>
-        /// Parses the 'text' of a slash command or 'subtext' of an outgoing WebHook of the form
+        /// Parses the parameters a slash command or of an outgoing WebHook of the form
         /// '<c>action param1; param2=value2; param3=value 3; param4="quoted value4"; ...</c>'.
         /// Parameter values containing semi-colons can either escape the semi-colon using a backslash character,
         /// i.e '\;', or quote the value using single quotes or double quotes.
@@ -62,141 +65,329 @@ namespace Microsoft.AspNetCore.WebHooks
         /// <example>
         /// An example of an outgoing WebHook or slash command using this format is
         /// <c>/appointment add title=doctor visit; time=Feb 3 2016 2 PM; location=Children's Hospital</c>
-        /// where '/appointment' is the trigger word or slash command, 'add' is the action and title, time, and location
-        /// are parameters.
+        /// where '/appointment' is the trigger word or slash command, 'add' is the action and title, time, and
+        /// location are parameters. In this case, caller would pass
+        /// <c>title=doctor visit; time=Feb 3 2016 2 PM; location=Children's Hospital</c> to this method.
         /// </example>
-        /// <param name="text">The 'text' of a slash command or 'subtext' of an outgoing WebHook.</param>
-        public static KeyValuePair<string, NameValueCollection> ParseActionWithParameters(string text)
+        /// <param name="text">
+        /// The parameter portion of a slash command or an outgoing WebHook. Often the
+        /// <see cref="KeyValuePair{StringSegment, StringSegment}.Value"/> from what
+        /// <see cref="ParseActionWithValue"/> returned.
+        /// </param>
+        /// <returns>
+        /// A <see cref="ValueTuple{T1, T2}"/> in which one property is always <see langword="null"/>. When successful,
+        /// <c>Error</c> is <see langword="null"/> and <c>Parameters</c> an <see cref="IDictionary{TKey, TValue}"/>
+        /// mapping zero or more parameter names to zero or more values. Otherwise, <c>Parameters</c> is
+        /// <see langword="null"/> and <c>Error</c> a <see cref="string"/> describing the specific problem.
+        /// </returns>
+        public static (IDictionary<StringSegment, IList<StringSegment>> Parameters, string Error) ParseParameters(
+            StringSegment text)
         {
-            var actionValue = ParseActionWithValue(text);
-
-            var parameters = new ParameterCollection();
-            var result = new KeyValuePair<string, NameValueCollection>(actionValue.Key, parameters);
-
-            var encodedSeparators = EncodeNonSeparatorCharacters(actionValue.Value);
-            var keyValuePairs = new TrimmingTokenizer(encodedSeparators, ParameterSeparator);
-            foreach (var keyValuePair in keyValuePairs)
+            var parameters = new Dictionary<StringSegment, IList<StringSegment>>(
+                StringSegmentComparer.OrdinalIgnoreCase);
+            var index = GetWhitespaceLength(text, initialIndex: 0);
+            while (index < text.Length)
             {
-                var parameter = new TrimmingTokenizer(keyValuePair, EqualSeparator, 2).ToArray();
-
-                var name = parameter[0].Value;
-                ValidateParameterName(name);
-
-                // Unquote and convert parameter value
-                var value = string.Empty;
-                if (parameter.Length > 1)
+                var (length, name, error) = GetParameterName(text, index);
+                if (error != null)
                 {
-                    value = parameter[1].Value;
-                    value = value.Trim(new[] { '\'' }).Trim('"');
-                    value = value.Replace("\\\0", ";");
+                    return (Parameters: null, error);
                 }
 
-                parameters.Add(name, value);
+                index += length;
+
+                var equalsLength = GetEqualsLength(text, index);
+                index += equalsLength;
+
+                var value = StringSegment.Empty;
+                if (equalsLength > 0)
+                {
+                    (length, value, error) = GetParameterValue(text, index);
+                    if (error != null)
+                    {
+                        return (Parameters: null, error);
+                    }
+
+                    index += length;
+                }
+
+                if (!(StringSegment.IsNullOrEmpty(name) && StringSegment.IsNullOrEmpty(value)))
+                {
+                    if (!parameters.TryGetValue(name, out var list))
+                    {
+                        list = new List<StringSegment>();
+                        parameters.Add(name, list);
+                    }
+
+                    list.Add(value);
+                }
+
+                index += GetSemicolonLength(text, index);
             }
 
-            return result;
+            return (parameters, Error: null);
         }
 
         /// <summary>
-        /// Verify that parameter name is not a quoted string and that it doesn't contain encoded ';' characters.
+        /// <para>
+        /// Returns a normalized representation of the given <paramref name="parameters"/>. This method and
+        /// <see cref="ParseParameters"/> round-trip the semantics of the original text.
+        /// </para>
+        /// <para>
+        /// Does not preserve syntax such as whitespace in the <see cref="StringSegment"/> passed to
+        /// <see cref="ParseParameters"/>, how parameter values were quoted, or the parameter order.
+        /// </para>
         /// </summary>
-        internal static void ValidateParameterName(string name)
+        /// <param name="parameters">The mapping of parameter names to zero or more parameter values.</param>
+        /// <returns>A normalized representation of the given <paramref name="parameters"/>.</returns>
+        public static string GetNormalizedParameterString(IDictionary<StringSegment, IList<StringSegment>> parameters)
         {
-            if (name.Length > 0 && (name[0] == '\'' || name[0] == '"'))
-            {
-                var message = string.Format(CultureInfo.CurrentCulture, Resources.Command_NameIsQuotedString, name);
-                throw new ArgumentException(message);
-            }
-
-            if (name.IndexOf("\\\0", StringComparison.Ordinal) > -1)
-            {
-                name = name.Replace("\\\0", ";");
-                var message = string.Format(CultureInfo.CurrentCulture, Resources.Command_NameInvalid, name);
-                throw new ArgumentException(message);
-            }
-        }
-
-        /// <summary>
-        /// Transform quoted or escaped ';' characters so that we can split the stream on actual
-        /// parameter separators.
-        /// </summary>
-        internal static string EncodeNonSeparatorCharacters(string text)
-        {
-            if (text == null || text.Length == 0)
+            if (parameters.Count == 0)
             {
                 return string.Empty;
             }
 
-            var normalized = new StringBuilder(text.Length);
-            var bytesConsumed = 0;
-            while (true)
+            var builder = new StringBuilder();
+            var addSemicolon = false;
+            foreach (var parameter in parameters)
             {
-                // Look for starting quote (either single or double)
-                if (text[bytesConsumed] == '\'' || text[bytesConsumed] == '"')
+                foreach (var parameterValue in parameter.Value)
                 {
-                    var quoteOffset = bytesConsumed;
-                    var quote = text[bytesConsumed];
-                    normalized.Append(quote);
-                    if (++bytesConsumed == text.Length)
+                    if (addSemicolon)
                     {
-                        var message = string.Format(
-                            CultureInfo.CurrentCulture,
-                            Resources.Command_ContainsUnmatchedQuote,
-                            quote,
-                            quoteOffset);
-                        throw new ArgumentException(message);
+                        builder.Append("; ");
                     }
 
-                    // Look for matching closing quote while encoding ';' on the way
-                    while (text[bytesConsumed] != quote)
+                    addSemicolon = true;
+                    builder.Append(parameter.Key.Value);
+                    if (StringSegment.IsNullOrEmpty(parameterValue))
                     {
-                        // Encode semicolon
-                        var ch = text[bytesConsumed];
-                        if (ch == ';')
-                        {
-                            normalized.Append("\\\0");
-                        }
-                        else
-                        {
-                            normalized.Append(ch);
-                        }
-
-                        if (++bytesConsumed == text.Length)
-                        {
-                            var message = string.Format(
-                                CultureInfo.CurrentCulture,
-                                Resources.Command_ContainsUnmatchedQuote,
-                                quote,
-                                quoteOffset);
-                            throw new ArgumentException(message);
-                        }
+                        continue;
                     }
 
-                    // Record and move past closing quote
-                    normalized.Append(text[bytesConsumed]);
-                    if (++bytesConsumed == text.Length)
+                    builder.Append('=');
+                    if (StringSegment.Equals(parameterValue, parameterValue.Trim(), StringComparison.Ordinal))
                     {
-                        return normalized.ToString();
+                        // No leading or trailing whitespace. Escape semicolons in value using backslashes.
+                        for (var i = 0; i < parameterValue.Length; i++)
+                        {
+                            var ch = parameterValue[i];
+                            if (ch == ';')
+                            {
+                                builder.Append('\\');
+                            }
+
+                            builder.Append(ch);
+                        }
                     }
-                }
-                else
-                {
-                    var ch = text[bytesConsumed];
-                    if (ch != ';' || (bytesConsumed > 0 && text[bytesConsumed - 1] != '\\'))
+                    else if (parameterValue.IndexOf('\'') == -1)
                     {
-                        normalized.Append(ch);
+                        // Need surrounding quotes and value does not contain single quotes. Use single quotes.
+                        builder.Append('\'');
+                        builder.Append(parameterValue.Value);
+                        builder.Append('\'');
                     }
                     else
                     {
-                        normalized.Append('\0');
-                    }
-
-                    if (++bytesConsumed == text.Length)
-                    {
-                        return normalized.ToString();
+                        // Need quotes and value contains single quotes. Use double quotes. (No way to escape quotes.)
+                        builder.Append('"');
+                        builder.Append(parameterValue.Value);
+                        builder.Append('"');
                     }
                 }
             }
+
+            return builder.ToString();
+        }
+
+        // Length is the number of characters required to reach equals separating a parameter name from its value,
+        // semicolon separating one parameter from another, or end of the given segment.
+        private static (int Length, StringSegment Value, string Error) GetParameterName(
+            StringSegment segment,
+            int initialIndex)
+        {
+            var index = initialIndex;
+            for (; index < segment.Length; index++)
+            {
+                // Names can be pretty much anything but must not contain quotes or an escaped backslash. Treated as
+                // StringSegment.Empty if only whitespace appears before the equals or semicolon.
+                var done = false;
+                switch (segment[index])
+                {
+                    case '\'':
+                    case '"':
+                        {
+                            var error = string.Format(
+                                CultureInfo.CurrentCulture,
+                                Resources.Command_NameIsQuotedString,
+                                segment[index],
+                                index);
+                            return (Length: 0, StringSegment.Empty, error);
+                        }
+
+                    case '=':
+                    case ';':
+                        done = true;
+                        break;
+
+                    case '\\':
+                        if (index < segment.Length - 1 && segment[index + 1] == ';')
+                        {
+                            // An attempt to include a quoted semicolon in a name. Message refers to escape sequence.
+                            var error = string.Format(
+                                CultureInfo.CurrentCulture,
+                                Resources.Command_NameInvalid,
+                                segment.Substring(index, 2),
+                                index);
+                            return (Length: 0, StringSegment.Empty, error);
+                        }
+
+                        // Nothing else to do: Backslashes just backslashes unless quoting semicolons outside a string.
+                        break;
+                }
+
+                if (done)
+                {
+                    break;
+                }
+            }
+
+            var name = segment.Subsegment(initialIndex, index - initialIndex).TrimEnd();
+
+            return (index - initialIndex, name, Error: null);
+        }
+
+        // Return number of characters required to reach start of the parameter value, semicolon separating one
+        // parameter from another, or end of the given segment.
+        private static int GetEqualsLength(StringSegment segment, int initialIndex)
+        {
+            if (initialIndex >= segment.Length || segment[initialIndex] != '=')
+            {
+                return 0;
+            }
+
+            return GetWhitespaceLength(segment, initialIndex + 1) + 1;
+        }
+
+        // Return number of characters required to reach start of the next parameter or end of the given segment.
+        private static int GetSemicolonLength(StringSegment segment, int initialIndex)
+        {
+            if (initialIndex >= segment.Length || segment[initialIndex] != ';')
+            {
+                return 0;
+            }
+
+            return GetWhitespaceLength(segment, initialIndex + 1) + 1;
+        }
+
+        // Length is the number of characters required to reach semicolon separating one parameter from another
+        // or end of the given segment.
+        private static (int Length, StringSegment Value, string Error) GetParameterValue(
+            StringSegment segment,
+            int initialIndex)
+        {
+            if (initialIndex >= segment.Length)
+            {
+                return (Length: 0, StringSegment.Empty, Error: null);
+            }
+
+            var firstChar = segment[initialIndex];
+            if (firstChar == '\'' || firstChar == '"')
+            {
+                var quoteIndex = segment.IndexOf(firstChar, initialIndex + 1);
+                if (quoteIndex == -1)
+                {
+                    var error = string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.Command_ContainsUnmatchedQuote,
+                        firstChar,
+                        initialIndex);
+                    return (Length: 0, StringSegment.Empty, error);
+                }
+
+                var index = quoteIndex + 1;
+                index += GetWhitespaceLength(segment, index);
+
+                if (index < segment.Length && segment[index] != ';')
+                {
+                    // Found something other than whitespace before the next semicolon or the end of the segment.
+                    var error = string.Format(
+                        CultureInfo.CurrentCulture,
+                        Resources.Command_ValueInvalid,
+                        segment[index],
+                        index);
+                    return (Length: 0, StringSegment.Empty, error);
+                }
+
+                var value = segment.Subsegment(initialIndex + 1, length: quoteIndex - initialIndex - 1);
+                return (index - initialIndex, value, Error: null);
+            }
+
+            var (length, unquotedValue) = GetUnquotedValue(segment, initialIndex);
+            return (length, unquotedValue, Error: null);
+        }
+
+        private static (int Length, StringSegment Value) GetUnquotedValue(StringSegment segment, int initialIndex)
+        {
+            var backslashesToRemove = 0;
+            var index = initialIndex;
+            for (; index < segment.Length; index++)
+            {
+                var done = false;
+                switch (segment[index])
+                {
+                    case ';':
+                        done = true;
+                        break;
+
+                    case '\\':
+                        if (index < segment.Length - 1 && segment[index + 1] == ';')
+                        {
+                            backslashesToRemove++;
+                            index++;
+                        }
+                        break;
+                }
+
+                if (done)
+                {
+                    break;
+                }
+            }
+
+            var length = index - initialIndex;
+            StringSegment value;
+            if (backslashesToRemove == 0)
+            {
+                value = segment.Subsegment(initialIndex, length);
+            }
+            else
+            {
+                var builder = new StringBuilder(length - backslashesToRemove);
+                for (var i = initialIndex; i < index; i++)
+                {
+                    // Append all characters except a backslash before a semicolon.
+                    var ch = segment[i];
+                    if (!(ch == '\\' && i < index - 1 && segment[i + 1] == ';'))
+                    {
+                        builder.Append(ch);
+                    }
+                }
+
+                value = new StringSegment(builder.ToString());
+            }
+
+            return (length, value.TrimEnd());
+        }
+
+        private static int GetWhitespaceLength(StringSegment segment, int initialIndex)
+        {
+            var index = initialIndex;
+            for (; index < segment.Length && char.IsWhiteSpace(segment[index]); index++)
+            {
+            }
+
+            return index - initialIndex;
         }
     }
 }

--- a/test/Microsoft.AspNetCore.WebHooks.Receivers.Slack.Test/Microsoft.AspNetCore.WebHooks.Receivers.Slack.Test.csproj
+++ b/test/Microsoft.AspNetCore.WebHooks.Receivers.Slack.Test/Microsoft.AspNetCore.WebHooks.Receivers.Slack.Test.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Configurations>$(Configurations);CodeAnalysis</Configurations>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.AspNetCore.WebHooks.Receivers.Slack\Microsoft.AspNetCore.WebHooks.Receivers.Slack.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Moq" Version="4.7.145" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.analyzers" Version="0.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+  </ItemGroup>
+</Project>

--- a/test/Microsoft.AspNetCore.WebHooks.Receivers.Slack.Test/SlackCommandTests.cs
+++ b/test/Microsoft.AspNetCore.WebHooks.Receivers.Slack.Test/SlackCommandTests.cs
@@ -1,0 +1,293 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Microsoft.AspNetCore.WebHooks
+{
+    public class SlackCommandTests
+    {
+        public static TheoryData<string, KeyValuePair<StringSegment, StringSegment>> ActionWithValueData
+        {
+            get
+            {
+                return new TheoryData<string, KeyValuePair<StringSegment, StringSegment>>
+                {
+                    { null, new KeyValuePair<StringSegment, StringSegment>(string.Empty, string.Empty) },
+                    { string.Empty, new KeyValuePair<StringSegment, StringSegment>(string.Empty, string.Empty) },
+                    { " ", new KeyValuePair<StringSegment, StringSegment>(string.Empty, string.Empty) },
+                    { "你好", new KeyValuePair<StringSegment, StringSegment>("你好", string.Empty) },
+                    { " 你好 ", new KeyValuePair<StringSegment, StringSegment>("你好", string.Empty) },
+                    { "你好 世界", new KeyValuePair<StringSegment, StringSegment>("你好", "世界") },
+                    { " 你好  世界 ", new KeyValuePair<StringSegment, StringSegment>("你好", "世界") },
+                    { "你好  世界", new KeyValuePair<StringSegment, StringSegment>("你好", "世界") },
+                    { "你好   世界", new KeyValuePair<StringSegment, StringSegment>("你好", "世界") },
+                    { "你 好 世 界", new KeyValuePair<StringSegment, StringSegment>("你", "好 世 界") },
+                    { "你 好;世\\界\\;", new KeyValuePair<StringSegment, StringSegment>("你", "好;世\\界\\;") },
+                    { " 你  好;世\\界\\; ", new KeyValuePair<StringSegment, StringSegment>("你", "好;世\\界\\;") },
+                };
+            }
+        }
+
+        public static TheoryData<string, string> RoundTripData
+        {
+            get
+            {
+                return new TheoryData<string, string>
+                {
+                    { null, string.Empty },
+                    { string.Empty, string.Empty },
+                    { "p1=v1", "p1=v1" },
+                    { "  p1 = v1 ", "p1=v1" },
+                    { "p1=v1; p1=v2", "p1=v1; p1=v2" },
+                    { "p1=v1    ;p2=v2", "p1=v1; p2=v2" },
+                    { "p1=v'1    ;p2=v\"2", "p1=v'1; p2=v\"2" },
+                    { "p1=' v1'; p2=\" v2\"", "p1=' v1'; p2=' v2'" },
+                    { "p1='v1 ';        p2=\"v2 \"", "p1='v1 '; p2='v2 '" },
+                    { "p1=v  1           ; p2=\"v  2\"   ", "p1=v  1; p2=v  2" },
+                    { "p1=' v1 '; p2=\" v2 \"", "p1=' v1 '; p2=' v2 '" },
+                    { "p1=' v\"1 '; p2=\" v'2 \"", "p1=' v\"1 '; p2=\" v'2 \"" },
+                    { "p1='v;1'; p2=\"v;2\"", "p1=v\\;1; p2=v\\;2" },
+                    { "p1=\\;v1; p2=v\\;2; p3=v3\\;", "p1=\\;v1; p2=v\\;2; p3=v3\\;" },
+                    { "p1=\\;v1; p2=v\\;2; p1=v3\\;", "p1=\\;v1; p1=v3\\;; p2=v\\;2" },
+                    { " 世=界", "世=界" },
+
+                    { "a=b;b=c", "a=b; b=c" },
+                    { "a=b; b=c", "a=b; b=c" },
+                    { "a=  b ; b=c", "a=b; b=c" },
+
+                    { "a;b", "a; b" },
+                    { "a;  b", "a; b" },
+                    { "a=;b=", "a; b" },
+                    { "a = ; b = ", "a; b" },
+                    { "a='';b=''", "a; b" },
+                    { "a=\"\";b=\"\"", "a; b" },
+                    { "a=  '';b=''", "a; b" },
+                    { "a=  \"\"  ;  b=\"\"", "a; b" },
+
+                    { "a='b';b='c'", "a=b; b=c" },
+                    { "a=\"b\";b=\"c\"", "a=b; b=c" },
+                    { "a=';b';b='c;'", "a=\\;b; b=c\\;" },
+                    { "a=\";b\";b=\"c;\"", "a=\\;b; b=c\\;" },
+
+                    { "abcd", "abcd" },
+                    { "a=abcd", "a=abcd" },
+                    { "a='abcd'", "a=abcd" },
+                    { "a=\"abcd\"", "a=abcd" },
+                    { "a=ab\\;cd", "a=ab\\;cd" },
+                    { "a='ab;cd'", "a=ab\\;cd" },
+                    { "a=\"ab;cd\"", "a=ab\\;cd" },
+                    { "a='ab\\;cd'", "a=ab\\\\;cd" },
+                    { "a=\"ab\\;cd\"", "a=ab\\\\;cd" },
+
+                    { "a=''", "a" },
+                    { "a=\"\"", "a" },
+                    { "a=\\;", "a=\\;" },
+                    { "a=';'", "a=\\;" },
+                    { "a=\";\"", "a=\\;" },
+
+                    { "a=\\;\\;\\;\\;", "a=\\;\\;\\;\\;" },
+                    { "a=\\;\\;;b=\\;\\;", "a=\\;\\;; b=\\;\\;" },
+                    { "a=';;;;'", "a=\\;\\;\\;\\;" },
+                    { "a=\";;;;\"", "a=\\;\\;\\;\\;" },
+                    { "a=';;';b=';;'", "a=\\;\\;; b=\\;\\;" },
+                    { "a=\";;\";b=\";;\"", "a=\\;\\;; b=\\;\\;" },
+                    { "a='\\;\\;\\;\\;'", "a=\\\\;\\\\;\\\\;\\\\;" },
+                    { "a=\"\\;\\;\\;\\;\"", "a=\\\\;\\\\;\\\\;\\\\;" },
+                    { "a='\\;\\;';b='\\;\\;'", "a=\\\\;\\\\;; b=\\\\;\\\\;" },
+                    { "a=\"\\;\\;\";b=\"\\;\\;\"", "a=\\\\;\\\\;; b=\\\\;\\\\;" },
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ActionWithValueData))]
+        public void ParseActionWithValue_HandlesInput(string text, KeyValuePair<StringSegment, StringSegment> expected)
+        {
+            // Arrange & Act
+            var actual = SlackCommand.ParseActionWithValue(text);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("text")]
+        [InlineData("  text")]
+        [InlineData("\\text")]
+        [InlineData("  text\\")]
+        [InlineData("  text\\ text  ")]
+        [InlineData("你 世界")]
+        [InlineData("  你 世界  ")]
+        public void ParseParameters_AcceptsValidName(string name)
+        {
+            // Arrange & Act
+            var expectedName = name.Trim();
+            var (result, error) = SlackCommand.ParseParameters(name);
+
+            // Assert
+            var keyValuePair = Assert.Single(result);
+            Assert.True(keyValuePair.Key.HasValue);
+            Assert.Equal(expectedName, keyValuePair.Key.Value);
+
+            var segment = Assert.Single(keyValuePair.Value);
+            Assert.True(StringSegment.IsNullOrEmpty(segment));
+
+            Assert.Null(error);
+        }
+
+        [Theory]
+        [InlineData("text", "text")]
+        [InlineData("  text", "text")]
+        [InlineData("你 世界", "你 世界")]
+        [InlineData("  你 世界  ", "你 世界")]
+        [InlineData("'text'", "text")]
+        [InlineData("  'text'", "text")]
+        [InlineData("  '  text'", "  text")]
+        [InlineData("  'text  '", "text  ")]
+        [InlineData("  '  text  '", "  text  ")]
+        [InlineData("'你 世界'", "你 世界")]
+        [InlineData("  '你 世界  '", "你 世界  ")]
+        [InlineData("\"text\"", "text")]
+        [InlineData("  \"text\"", "text")]
+        [InlineData("  \"  text\"", "  text")]
+        [InlineData("  \"text  \"", "text  ")]
+        [InlineData("  \"  text  \"", "  text  ")]
+        [InlineData("\"你 世界\"", "你 世界")]
+        [InlineData("  \"你 世界  \"", "你 世界  ")]
+        [InlineData("text'text", "text'text")]
+        [InlineData("text \" text", "text \" text")]
+        [InlineData("  text \" text  ", "text \" text")]
+        [InlineData("\\", "\\")]
+        [InlineData("\\;", ";")]
+        [InlineData("\\\\;", "\\;")]
+        [InlineData("\\;\\", ";\\")]
+        [InlineData("  \\;  ", ";")]
+        [InlineData("';'", ";")]
+        [InlineData("  ';;'  ", ";;")]
+        [InlineData("'  ;;;  '", "  ;;;  ")]
+        [InlineData("'  ;\";  '", "  ;\";  ")]
+        [InlineData("\";\"", ";")]
+        [InlineData("  \";;\"  ", ";;")]
+        [InlineData("\"  ;;;  \"", "  ;;;  ")]
+        [InlineData("\"  ;';  \"", "  ;';  ")]
+        public void ParseParameters_AcceptsValidValue(string value, string expectedValue)
+        {
+            // Arrange & Act
+            var (result, error) = SlackCommand.ParseParameters($"name={value}");
+
+            // Assert
+            var keyValuePair = Assert.Single(result);
+            Assert.True(keyValuePair.Key.HasValue);
+            Assert.Equal("name", keyValuePair.Key.Value);
+
+            var segment = Assert.Single(keyValuePair.Value);
+            Assert.True(segment.HasValue);
+            Assert.Equal(expectedValue, segment.Value);
+
+            Assert.Null(error);
+        }
+
+        [Theory]
+        [MemberData(nameof(RoundTripData))]
+        public void ParseParameters_GetNormalizedParameterString_RoundTrips(string text, string expectedParameters)
+        {
+            // Arrange & Act
+            var (result, error) = SlackCommand.ParseParameters(text);
+            var actual = SlackCommand.GetNormalizedParameterString(result);
+
+            // Assert
+            Assert.Null(error);
+            Assert.Equal(expectedParameters, actual);
+        }
+
+        [Theory]
+        [InlineData("'text'", '\'', 0)]
+        [InlineData("\"text\"", '"', 0)]
+        [InlineData("   \"text\"", '"', 3)]
+        public void ParseParameters_ReturnsError_IfQuotedName(string name, char quote, int offset)
+        {
+            // Arrange
+            var expected = $"Parameter name cannot be a quoted string. Unexpected character ({quote}) " +
+                $"discovered at position {offset}.";
+
+            // Act
+            var (result, error) = SlackCommand.ParseParameters(name);
+
+            // Assert
+            Assert.Null(result);
+            Assert.StartsWith(expected, error);
+        }
+
+        [Theory]
+        [InlineData("\\;text", 0)]
+        [InlineData("te\\;xt", 2)]
+        [InlineData("te\\;\\;xt", 2)]
+        [InlineData("text\\;", 4)]
+        [InlineData("  \\;text  ", 2)]
+        [InlineData("  te\\;xt", 4)]
+        [InlineData("  text\\;  ", 6)]
+        public void ParseParameters_ReturnsError_IfInvalidName(string name, int offset)
+        {
+            // Arrange
+            var expected = "Parameter name cannot contain ';' characters. Unexpected escape sequence (\\;) " +
+                $"discovered at position {offset}.";
+
+            // Act
+            var (result, error) = SlackCommand.ParseParameters(name);
+
+            // Assert
+            Assert.Null(result);
+            Assert.Equal(expected, error);
+        }
+
+        [Theory]
+        [InlineData("a='", '\'', 2 )]
+        [InlineData("a=\"", '"', 2 )]
+        [InlineData("  a=\"", '"', 4)]
+        [InlineData("a='b;b=c", '\'', 2)]
+        [InlineData("  a='b;  b=c", '\'', 4)]
+        [InlineData("a=\"b;b=c", '"', 2)]
+        [InlineData("a='b;b=\"c\"", '\'', 2)]
+        [InlineData("a=\"b;b='c'", '"', 2)]
+        [InlineData("   a=\"b;  b='c'  ", '"', 5)]
+        public void ParseParameters_ReturnsError_IfValueContainsMismatchedQuote(string input, char quote, int offset)
+        {
+            // Arrange
+            var expected = $"Unmatched quote ({quote}) discovered at position {offset}.";
+
+            // Act
+            var (result, error) = SlackCommand.ParseParameters(input);
+
+            // Assert
+            Assert.Null(result);
+            Assert.Equal(expected, error);
+        }
+
+        [Theory]
+        [InlineData("a='''", '\'', 4)]
+        [InlineData("a=\"\"\"", '"', 4)]
+        [InlineData("  a=\"\"\"", '"', 6)]
+        [InlineData("a='b;b='c'", 'c', 8)]
+        [InlineData("  a='b;b='  c'", 'c', 12)]
+        [InlineData("a=\"b;b=\"c\"", 'c', 8)]
+        [InlineData("a=';b;b='c;'", 'c', 9)]
+        [InlineData("a=\";b;b=\"c;\"", 'c', 9)]
+        [InlineData("  a=\";b;b=\" c; \"", 'c', 12)]
+        public void ParseParameters_ReturnsError_IfTextFoundAfterQuotedString(string input, char ch, int offset)
+        {
+            // Arrange
+            var expected = $"Parameter value contains text after a quoted string. Unexpected character ({ch}) " +
+                $"discovered at position {offset}.";
+
+            // Act
+            var (result, error) = SlackCommand.ParseParameters(input);
+
+            // Assert
+            Assert.Null(result);
+            Assert.Equal(expected, error);
+        }
+    }
+}


### PR DESCRIPTION
- part of #178
- refactor API to return errors and avoid wrapping `ParseActionWithValue(...)`
  - stop `throw`ing `ArgumentException`s for unexpected user input
- add a real parser for Slack commands containing name/value parameter pairs
- add tests originally cribbed from ASP.NET WebHooks