### PR TITLE
Improve doc comments

### DIFF
--- a/samples/PusherCoreReceiver/wwwroot/index.html
+++ b/samples/PusherCoreReceiver/wwwroot/index.html
@@ -9,14 +9,13 @@
 
     <p>
         This sample illustrates how to wire up a Pusher WebHooks receiver. A sample WebHook URI is:
-        <code>https://&lt;host&gt;/api/webhooks/incoming/pusher/{id}</code>
+        <code>https://{host}/api/webhooks/incoming/pusher/{id}</code>
     </p>
 
     <p>
-        Set the <code>MS_WebHookReceiverSecret_Pusher</code> configuration value to the Pusher application key / secret
-        key pairs, optionally using IDs to differentiate between multiple WebHooks. Key pairs are divided by
-        underscores, pairs are separated by semicolons, and IDs are separated by commas. For example
-        <code>47e5a8cd8f6bb492252a_42fef23870926753d345; ba3af8f38f3be37d476a_9eb6d047bb5465a43cb2, id1=39edd0bdb9834a588e98_16e92a1c11b6b2f43df7</code>.
+        Set <code>WebHooks:Pusher:SecretKey:{id}:{application key}</code> configuration values to the corresponding
+        secret keys. That is, match the Pusher application key / secret key pairs and optionally use IDs to
+        differentiate between multiple WebHooks.
     </p>
 
     <p>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.AzureAlert/AzureAlertWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.AzureAlert/AzureAlertWebHookAttribute.cs
@@ -10,27 +10,38 @@ namespace Microsoft.AspNetCore.WebHooks
     /// <see cref="Filters.WebHookReceiverExistsFilter"/> for the action.
     /// </para>
     /// <para>
+    /// The signature of the action should be:
+    /// <code>
+    /// Task{IActionResult} ActionName(string id, string @event, TData data)
+    /// </code>
+    /// or include the subset of parameters required. <c>TData</c> must be compatible with expected requests e.g.
+    /// <see cref="Newtonsoft.Json.Linq.JObject"/> or <see cref="AzureAlertNotification"/>.
+    /// </para>
+    /// <para>
     /// An example Azure Alert WebHook URI is
-    /// '<c>https://&lt;host&gt;/api/webhooks/incoming/azurealert/{id}?code=83699ec7c1d794c0c780e49a5c72972590571fd8</c>'.
-    /// See <see href="https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/insights-webhooks-alerts"/>
+    /// '<c>https://{host}/api/webhooks/incoming/azurealert/{id}?code=83699ec7c1d794c0c780e49a5c72972590571fd8</c>'.
+    /// See
+    /// <see href="https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/insights-webhooks-alerts"/>
     /// for additional details about Azure Alert WebHook requests.
     /// </para>
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If the application enables CORS in general (see the <c>Microsoft.AspNetCore.Cors</c> package), apply
+    /// <c>DisableCorsAttribute</c> to this action. If the application depends on the
+    /// <c>Microsoft.AspNetCore.Mvc.ViewFeatures</c> package, apply <c>IgnoreAntiforgeryTokenAttribute</c> to this
+    /// action.
+    /// </para>
+    /// <para>
+    /// <see cref="AzureAlertWebHookAttribute"/> should be used at most once per <see cref="WebHookAttribute.Id"/> in a
+    /// WebHook application.
+    /// </para>
+    /// </remarks>
     public class AzureAlertWebHookAttribute : WebHookAttribute
     {
         /// <summary>
-        /// <para>
         /// Instantiates a new <see cref="AzureAlertWebHookAttribute"/> indicating the associated action is an Azure
         /// Alert WebHook endpoint.
-        /// </para>
-        /// <para>The signature of the action should be:
-        /// <code>
-        /// Task{IActionResult} ActionName(string id, TData data)
-        /// </code>
-        /// or include the subset of parameters required. <c>TData</c> must be compatible with expected requests e.g.
-        /// <see cref="Newtonsoft.Json.Linq.JObject"/> or <see cref="AzureAlertNotification"/>.
-        /// </para>
-        /// <para>This constructor should usually be used at most once in a WebHook application.</para>
         /// </summary>
         public AzureAlertWebHookAttribute()
             : base(AzureAlertConstants.ReceiverName)

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.AzureAlert/Extensions/AzureAlertMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.AzureAlert/Extensions/AzureAlertMvcBuilderExtensions.cs
@@ -14,7 +14,18 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class AzureAlertMvcBuilderExtensions
     {
         /// <summary>
-        /// Add Azure Alert WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add Azure Alert WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/insights-webhooks-alerts"/>
+        /// for additional details about Azure Alert WebHook requests.
+        /// </para>
+        /// <para>
+        /// The '<c>WebHooks:AzureAlert:SecretKey:default</c>' configuration value contains the secret key for Azure
+        /// Alert WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/azurealert?code={secret key}</c>'.
+        /// '<c>WebHooks:AzureAlert:SecretKey:{id}</c>' configuration values contain secret keys for
+        /// Azure Alert WebHook URIs of the form
+        /// '<c>https://{host}/api/webhooks/incoming/azurealert/{id}?code={secret key}</c>'.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.AzureAlert/Extensions/AzureAlertMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.AzureAlert/Extensions/AzureAlertMvcCoreBuilderExtensions.cs
@@ -14,7 +14,18 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class AzureAlertMvcCoreBuilderExtensions
     {
         /// <summary>
-        /// Add Azure Alert WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add Azure Alert WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/insights-webhooks-alerts"/>
+        /// for additional details about Azure Alert WebHook requests.
+        /// </para>
+        /// <para>
+        /// The '<c>WebHooks:AzureAlert:SecretKey:default</c>' configuration value contains the secret key for Azure
+        /// Alert WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/azurealert?code={secret key}</c>'.
+        /// '<c>WebHooks:AzureAlert:SecretKey:{id}</c>' configuration values contain secret keys for
+        /// Azure Alert WebHook URIs of the form
+        /// '<c>https://{host}/api/webhooks/incoming/azurealert/{id}?code={secret key}</c>'.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcCoreBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.BitBucket/BitbucketWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.BitBucket/BitbucketWebHookAttribute.cs
@@ -10,33 +10,43 @@ namespace Microsoft.AspNetCore.WebHooks
     /// <summary>
     /// <para>
     /// An <see cref="Attribute"/> indicating the associated action is a Bitbucket WebHook endpoint.
-    /// Specifies the optional <see cref="WebHookAttribute.Id"/>. Also adds a
+    /// Specifies the optional <see cref="WebHookAttribute.Id"/> and <see cref="EventName"/>. Also adds a
     /// <see cref="Filters.WebHookReceiverExistsFilter"/> for the action.
     /// </para>
     /// <para>
+    /// The signature of the action should be:
+    /// <code>
+    /// Task{IActionResult} ActionName(string id, string @event, string webHookId, TData data)
+    /// </code>
+    /// or include the subset of parameters required. <c>TData</c> must be compatible with expected requests e.g.
+    /// <see cref="Newtonsoft.Json.Linq.JObject"/>.
+    /// </para>
+    /// <para>
     /// An example Bitbucket WebHook URI is
-    /// '<c>https://&lt;host&gt;/api/webhooks/incoming/bitbucket/{id}?code=83699ec7c1d794c0c780e49a5c72972590571fd8</c>'.
+    /// '<c>https://{host}/api/webhooks/incoming/bitbucket/{id}?code=83699ec7c1d794c0c780e49a5c72972590571fd8</c>'.
     /// See <see href="https://confluence.atlassian.com/bitbucket/manage-webhooks-735643732.html"/> for additional
     /// details about Bitbucket WebHook requests.
     /// </para>
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If the application enables CORS in general (see the <c>Microsoft.AspNetCore.Cors</c> package), apply
+    /// <c>DisableCorsAttribute</c> to this action. If the application depends on the
+    /// <c>Microsoft.AspNetCore.Mvc.ViewFeatures</c> package, apply <c>IgnoreAntiforgeryTokenAttribute</c> to this
+    /// action.
+    /// </para>
+    /// <para>
+    /// <see cref="BitbucketWebHookAttribute"/> should be used at most once per <see cref="WebHookAttribute.Id"/> and
+    /// <see cref="EventName"/> in a WebHook application.
+    /// </para>
+    /// </remarks>
     public class BitbucketWebHookAttribute : WebHookAttribute, IWebHookEventSelectorMetadata
     {
         private string _eventName;
 
         /// <summary>
-        /// <para>
         /// Instantiates a new <see cref="BitbucketWebHookAttribute"/> indicating the associated action is a Bitbucket
         /// WebHook endpoint.
-        /// </para>
-        /// <para>The signature of the action should be:
-        /// <code>
-        /// Task{IActionResult} ActionName(string id, string @event, string webHookId, TData data)
-        /// </code>
-        /// or include the subset of parameters required. <c>TData</c> must be compatible with expected requests e.g.
-        /// <see cref="Newtonsoft.Json.Linq.JObject"/>.
-        /// </para>
-        /// <para>This constructor should usually be used at most once in a WebHook application.</para>
         /// </summary>
         public BitbucketWebHookAttribute()
             : base(BitbucketConstants.ReceiverName)

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.BitBucket/Extensions/BitbucketMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.BitBucket/Extensions/BitbucketMvcBuilderExtensions.cs
@@ -14,7 +14,17 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class BitbucketMvcBuilderExtensions
     {
         /// <summary>
-        /// Add Bitbucket WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add Bitbucket WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://confluence.atlassian.com/bitbucket/manage-webhooks-735643732.html"/> for additional
+        /// details about Bitbucket WebHook requests.
+        /// </para>
+        /// <para>
+        /// The '<c>WebHooks:Bitbucket:SecretKey:default</c>' configuration value contains the secret key for Bitbucket
+        /// WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/bitbucket?code={secret key}</c>'.
+        /// '<c>WebHooks:Bitbucket:SecretKey:{id}</c>' configuration values contain secret keys for Bitbucket WebHook
+        /// URIs of the form '<c>https://{host}/api/webhooks/incoming/bitbucket/{id}?code={secret key}</c>'.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.BitBucket/Extensions/BitbucketMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.BitBucket/Extensions/BitbucketMvcCoreBuilderExtensions.cs
@@ -14,7 +14,17 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class BitbucketMvcCoreBuilderExtensions
     {
         /// <summary>
-        /// Add Bitbucket WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add Bitbucket WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://confluence.atlassian.com/bitbucket/manage-webhooks-735643732.html"/> for additional
+        /// details about Bitbucket WebHook requests.
+        /// </para>
+        /// <para>
+        /// The '<c>WebHooks:Bitbucket:SecretKey:default</c>' configuration value contains the secret key for Bitbucket
+        /// WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/bitbucket?code={secret key}</c>'.
+        /// '<c>WebHooks:Bitbucket:SecretKey:{id}</c>' configuration values contain secret keys for Bitbucket WebHook
+        /// URIs of the form '<c>https://{host}/api/webhooks/incoming/bitbucket/{id}?code={secret key}</c>'.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcCoreBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Dropbox/DropboxWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Dropbox/DropboxWebHookAttribute.cs
@@ -10,26 +10,36 @@ namespace Microsoft.AspNetCore.WebHooks
     /// the action.
     /// </para>
     /// <para>
-    /// An example Dropbox WebHook URI is '<c>https://&lt;host&gt;/api/webhooks/incoming/dropbox/{id}</c>'. See
+    /// The signature of the action should be:
+    /// <code>
+    /// Task{IActionResult} ActionName(string id, string @event, TData data)
+    /// </code>
+    /// or include the subset of parameters required. <c>@event</c> will always contain the value <c>"change"</c>.
+    /// <c>TData</c> must be compatible with expected requests e.g. <see cref="Newtonsoft.Json.Linq.JObject"/>.
+    /// </para>
+    /// <para>
+    /// An example Dropbox WebHook URI is '<c>https://{host}/api/webhooks/incoming/dropbox/{id}</c>'. See
     /// <see href="https://www.dropbox.com/developers/webhooks/docs"/> for additional details about Dropbox WebHook
     /// requests.
     /// </para>
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If the application enables CORS in general (see the <c>Microsoft.AspNetCore.Cors</c> package), apply
+    /// <c>DisableCorsAttribute</c> to this action. If the application depends on the
+    /// <c>Microsoft.AspNetCore.Mvc.ViewFeatures</c> package, apply <c>IgnoreAntiforgeryTokenAttribute</c> to this
+    /// action.
+    /// </para>
+    /// <para>
+    /// <see cref="DropboxWebHookAttribute"/> should be used at most once per <see cref="WebHookAttribute.Id"/> in a
+    /// WebHook application.
+    /// </para>
+    /// </remarks>
     public class DropboxWebHookAttribute : WebHookAttribute
     {
         /// <summary>
-        /// <para>
         /// Instantiates a new <see cref="DropboxWebHookAttribute"/> indicating the associated action is a Dropbox
         /// WebHook endpoint.
-        /// </para>
-        /// <para>The signature of the action should be:
-        /// <code>
-        /// Task{IActionResult} ActionName(string id, string @event, TData data)
-        /// </code>
-        /// or include the subset of parameters required. <c>@event</c> will always contain the value <c>"change"</c>.
-        /// <c>TData</c> must be compatible with expected requests e.g. <see cref="Newtonsoft.Json.Linq.JObject"/>.
-        /// </para>
-        /// <para>This constructor should usually be used at most once in a WebHook application.</para>
         /// </summary>
         public DropboxWebHookAttribute()
             : base(DropboxConstants.ReceiverName)

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Dropbox/Extensions/DropboxMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Dropbox/Extensions/DropboxMvcBuilderExtensions.cs
@@ -14,7 +14,17 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class DropboxMvcBuilderExtensions
     {
         /// <summary>
-        /// Add Dropbox WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add Dropbox WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://www.dropbox.com/developers/webhooks/docs"/> for additional details about Dropbox WebHook
+        /// requests.
+        /// </para>
+        /// <para>
+        /// The '<c>WebHooks:Dropbox:SecretKey:default</c>' configuration value contains the secret key for Dropbox
+        /// WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/dropbox</c>'.
+        /// '<c>WebHooks:Dropbox:SecretKey:{id}</c>' configuration values contain secret keys for Dropbox WebHook URIs
+        /// of the form '<c>https://{host}/api/webhooks/incoming/dropbox/{id}</c>'.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Dropbox/Extensions/DropboxMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Dropbox/Extensions/DropboxMvcCoreBuilderExtensions.cs
@@ -14,7 +14,17 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class DropboxMvcCoreBuilderExtensions
     {
         /// <summary>
-        /// Add Dropbox WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add Dropbox WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://www.dropbox.com/developers/webhooks/docs"/> for additional details about Dropbox WebHook
+        /// requests.
+        /// </para>
+        /// <para>
+        /// The '<c>WebHooks:Dropbox:SecretKey:default</c>' configuration value contains the secret key for Dropbox
+        /// WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/dropbox</c>'.
+        /// '<c>WebHooks:Dropbox:SecretKey:{id}</c>' configuration values contain secret keys for Dropbox WebHook URIs
+        /// of the form '<c>https://{host}/api/webhooks/incoming/dropbox/{id}</c>'.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcCoreBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.DynamicsCRM/DynamicsCRMWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.DynamicsCRM/DynamicsCRMWebHookAttribute.cs
@@ -10,27 +10,37 @@ namespace Microsoft.AspNetCore.WebHooks
     /// <see cref="Filters.WebHookReceiverExistsFilter"/> for the action.
     /// </para>
     /// <para>
+    /// The signature of the action should be:
+    /// <code>
+    /// Task{IActionResult} ActionName(string id, string @event, TData data)
+    /// </code>
+    /// or include the subset of parameters required. <c>TData</c> must be compatible with expected requests e.g.
+    /// <see cref="Newtonsoft.Json.Linq.JObject"/>.
+    /// </para>
+    /// <para>
     /// An example Dynamics CRM WebHook URI is
-    /// '<c>https://&lt;host&gt;/api/webhooks/incoming/dynamicscrm/{id}?code=83699ec7c1d794c0c780e49a5c72972590571fd8</c>'.
-    /// See <see href="http://go.microsoft.com/fwlink/?LinkId=722218"/> for additional details about Dynamics CRM
+    /// '<c>https://{host}/api/webhooks/incoming/dynamicscrm/{id}?code=83699ec7c1d794c0c780e49a5c72972590571fd8</c>'.
+    /// See <see href="https://go.microsoft.com/fwlink/?LinkId=722218"/> for additional details about Dynamics CRM
     /// WebHook requests.
     /// </para>
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If the application enables CORS in general (see the <c>Microsoft.AspNetCore.Cors</c> package), apply
+    /// <c>DisableCorsAttribute</c> to this action. If the application depends on the
+    /// <c>Microsoft.AspNetCore.Mvc.ViewFeatures</c> package, apply <c>IgnoreAntiforgeryTokenAttribute</c> to this
+    /// action.
+    /// </para>
+    /// <para>
+    /// <see cref="DynamicsCRMWebHookAttribute"/> should be used at most once per <see cref="WebHookAttribute.Id"/> in
+    /// a WebHook application.
+    /// </para>
+    /// </remarks>
     public class DynamicsCRMWebHookAttribute : WebHookAttribute
     {
         /// <summary>
-        /// <para>
         /// Instantiates a new <see cref="DynamicsCRMWebHookAttribute"/> indicating the associated action is a Dynamics
         /// CRM WebHook endpoint.
-        /// </para>
-        /// <para>The signature of the action should be:
-        /// <code>
-        /// Task{IActionResult} ActionName(string id, TData data)
-        /// </code>
-        /// or include the subset of parameters required. <c>TData</c> must be compatible with expected requests e.g.
-        /// <see cref="Newtonsoft.Json.Linq.JObject"/>.
-        /// </para>
-        /// <para>This constructor should usually be used at most once in a WebHook application.</para>
         /// </summary>
         public DynamicsCRMWebHookAttribute()
             : base(DynamicsCRMConstants.ReceiverName)

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.DynamicsCRM/Extensions/DynamicsCRMMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.DynamicsCRM/Extensions/DynamicsCRMMvcBuilderExtensions.cs
@@ -8,13 +8,24 @@ using Microsoft.AspNetCore.WebHooks.Internal;
 namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
-    /// Extension methods for setting up Dynamic CRM WebHooks in an <see cref="IMvcBuilder" />.
+    /// Extension methods for setting up Dynamics CRM WebHooks in an <see cref="IMvcBuilder" />.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class DynamicsCRMMvcBuilderExtensions
     {
         /// <summary>
-        /// Add Dynamic CRM WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add Dynamics CRM WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://go.microsoft.com/fwlink/?LinkId=722218"/> for additional details about Dynamics CRM
+        /// WebHook requests.
+        /// </para>
+        /// <para>
+        /// The '<c>WebHooks:DynamicsCrm:SecretKey:default</c>' configuration value contains the secret key for
+        /// Dynamics CRM WebHook URIs of the form
+        /// '<c>https://{host}/api/webhooks/incoming/dynamicscrm?code={secret key}</c>'.
+        /// '<c>WebHooks:DynamicsCrm:SecretKey:{id}</c>' configuration values contain secret keys for Dynamics CRM
+        /// WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/dynamicscrm/{id}?code={secret key}</c>'.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.DynamicsCRM/Extensions/DynamicsCRMMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.DynamicsCRM/Extensions/DynamicsCRMMvcCoreBuilderExtensions.cs
@@ -8,13 +8,24 @@ using Microsoft.AspNetCore.WebHooks.Internal;
 namespace Microsoft.Extensions.DependencyInjection
 {
     /// <summary>
-    /// Extension methods for setting up Dynamic CRM WebHooks in an <see cref="IMvcCoreBuilder" />.
+    /// Extension methods for setting up Dynamics CRM WebHooks in an <see cref="IMvcCoreBuilder" />.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class DynamicsCRMMvcCoreBuilderExtensions
     {
         /// <summary>
-        /// Add Dynamic CRM WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add Dynamics CRM WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://go.microsoft.com/fwlink/?LinkId=722218"/> for additional details about Dynamics CRM
+        /// WebHook requests.
+        /// </para>
+        /// <para>
+        /// The '<c>WebHooks:DynamicsCrm:SecretKey:default</c>' configuration value contains the secret key for
+        /// Dynamics CRM WebHook URIs of the form
+        /// '<c>https://{host}/api/webhooks/incoming/dynamicscrm?code={secret key}</c>'.
+        /// '<c>WebHooks:DynamicsCrm:SecretKey:{id}</c>' configuration values contain secret keys for Dynamics CRM
+        /// WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/dynamicscrm/{id}?code={secret key}</c>'.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcCoreBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.GitHub/Extensions/GitHubMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.GitHub/Extensions/GitHubMvcBuilderExtensions.cs
@@ -14,7 +14,16 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class GitHubMvcBuilderExtensions
     {
         /// <summary>
-        /// Add GitHub WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add GitHub WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://developer.github.com/webhooks/"/> for additional details about GitHub WebHook requests.
+        /// </para>
+        /// <para>
+        /// The '<c>WebHooks:GitHub:SecretKey:default</c>' configuration value contains the secret key for GitHub
+        /// WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/github</c>'.
+        /// '<c>WebHooks:GitHub:SecretKey:{id}</c>' configuration values contain secret keys for GitHub WebHook URIs of
+        /// the form '<c>https://{host}/api/webhooks/incoming/github/{id}</c>'.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.GitHub/Extensions/GitHubMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.GitHub/Extensions/GitHubMvcCoreBuilderExtensions.cs
@@ -14,7 +14,16 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class GitHubMvcCoreBuilderExtensions
     {
         /// <summary>
-        /// Add GitHub WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add GitHub WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://developer.github.com/webhooks/"/> for additional details about GitHub WebHook requests.
+        /// </para>
+        /// <para>
+        /// The '<c>WebHooks:GitHub:SecretKey:default</c>' configuration value contains the secret key for GitHub
+        /// WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/github</c>'.
+        /// '<c>WebHooks:GitHub:SecretKey:{id}</c>' configuration values contain secret keys for GitHub WebHook URIs of
+        /// the form '<c>https://{host}/api/webhooks/incoming/github/{id}</c>'.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcCoreBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.GitHub/GitHubWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.GitHub/GitHubWebHookAttribute.cs
@@ -10,32 +10,41 @@ namespace Microsoft.AspNetCore.WebHooks
     /// <summary>
     /// <para>
     /// An <see cref="Attribute"/> indicating the associated action is a GitHub WebHook endpoint. Specifies whether
-    /// the action <see cref="AcceptFormData"/>, optional <see cref="EventName"/>, and optional
-    /// <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="Filters.WebHookReceiverExistsFilter"/> for
-    /// the action.
+    /// the action should <see cref="AcceptFormData"/>, optional <see cref="EventName"/>, and optional
+    /// <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="Filters.WebHookReceiverExistsFilter"/> for the
+    /// action.
     /// </para>
     /// <para>
-    /// An example GitHub WebHook URI is
-    /// '<c>https://&lt;host&gt;/api/webhooks/incoming/github/{id}</c>'. See
+    /// The signature of the action should be:
+    /// <code>
+    /// Task{IActionResult} ActionName(string id, string @event, TData data)
+    /// </code>
+    /// or include the subset of parameters required. <c>TData</c> must be compatible with expected requests.
+    /// </para>
+    /// <para>
+    /// An example GitHub WebHook URI is '<c>https://{host}/api/webhooks/incoming/github/{id}</c>'. See
     /// <see href="https://developer.github.com/webhooks/"/> for additional details about GitHub WebHook requests.
     /// </para>
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If the application enables CORS in general (see the <c>Microsoft.AspNetCore.Cors</c> package), apply
+    /// <c>DisableCorsAttribute</c> to this action. If the application depends on the
+    /// <c>Microsoft.AspNetCore.Mvc.ViewFeatures</c> package, apply <c>IgnoreAntiforgeryTokenAttribute</c> to this
+    /// action.
+    /// </para>
+    /// <para>
+    /// <see cref="GitHubWebHookAttribute"/> should be used at most once per <see cref="WebHookAttribute.Id"/> and
+    /// <see cref="EventName"/> in a WebHook application.
+    /// </para>
+    /// </remarks>
     public class GitHubWebHookAttribute : WebHookAttribute, IWebHookBodyTypeMetadata, IWebHookEventSelectorMetadata
     {
         private string _eventName;
 
         /// <summary>
-        /// <para>
         /// Instantiates a new <see cref="GitHubWebHookAttribute"/> indicating the associated action is a GitHub
         /// WebHook endpoint.
-        /// </para>
-        /// <para>The signature of the action should be:
-        /// <code>
-        /// Task{IActionResult} ActionName(string id, string @event, TData data)
-        /// </code>
-        /// or include the subset of parameters required. <c>TData</c> must be compatible with expected requests.
-        /// </para>
-        /// <para>This constructor should usually be used at most once in a WebHook application.</para>
         /// </summary>
         public GitHubWebHookAttribute()
             : base(GitHubConstants.ReceiverName)

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Kudu/Extensions/KuduMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Kudu/Extensions/KuduMvcBuilderExtensions.cs
@@ -14,7 +14,17 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class KuduMvcBuilderExtensions
     {
         /// <summary>
-        /// Add Kudu WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add Kudu WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://github.com/projectkudu/kudu/wiki/Web-hooks"/> for additional details about Kudu WebHook
+        /// requests.
+        /// </para>
+        /// <para>
+        /// The '<c>WebHooks:Kudu:SecretKey:default</c>' configuration value contains the secret key for Kudu WebHook
+        /// URIs of the form '<c>https://{host}/api/webhooks/incoming/kudu?code={secret key}</c>'.
+        /// '<c>WebHooks:Kudu:SecretKey:{id}</c>' configuration values contain secret keys for Kudu WebHook URIs of the
+        /// form '<c>https://{host}/api/webhooks/incoming/kudu/{id}?code={secret key}</c>'.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Kudu/Extensions/KuduMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Kudu/Extensions/KuduMvcCoreBuilderExtensions.cs
@@ -14,7 +14,17 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class KuduMvcCoreBuilderExtensions
     {
         /// <summary>
-        /// Add Kudu WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add Kudu WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://github.com/projectkudu/kudu/wiki/Web-hooks"/> for additional details about Kudu WebHook
+        /// requests.
+        /// </para>
+        /// <para>
+        /// The '<c>WebHooks:Kudu:SecretKey:default</c>' configuration value contains the secret key for Kudu WebHook
+        /// URIs of the form '<c>https://{host}/api/webhooks/incoming/kudu?code={secret key}</c>'.
+        /// '<c>WebHooks:Kudu:SecretKey:{id}</c>' configuration values contain secret keys for Kudu WebHook URIs of the
+        /// form '<c>https://{host}/api/webhooks/incoming/kudu/{id}?code={secret key}</c>'.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcCoreBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Kudu/KuduWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Kudu/KuduWebHookAttribute.cs
@@ -10,27 +10,37 @@ namespace Microsoft.AspNetCore.WebHooks
     /// the action.
     /// </para>
     /// <para>
+    /// The signature of the action should be:
+    /// <code>
+    /// Task{IActionResult} ActionName(string id, string @event, TData data)
+    /// </code>
+    /// or include the subset of parameters required. <c>TData</c> must be compatible with expected requests e.g.
+    /// <see cref="Newtonsoft.Json.Linq.JObject"/> or <see cref="KuduNotification"/>.
+    /// </para>
+    /// <para>
     /// An example Kudu WebHook URI is
-    /// '<c>https://&lt;host&gt;/api/webhooks/incoming/kudu/{id}?code=83699ec7c1d794c0c780e49a5c72972590571fd8</c>'.
+    /// '<c>https://{host}/api/webhooks/incoming/kudu/{id}?code=83699ec7c1d794c0c780e49a5c72972590571fd8</c>'.
     /// See <see href="https://github.com/projectkudu/kudu/wiki/Web-hooks"/> for additional details about Kudu WebHook
     /// requests.
     /// </para>
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If the application enables CORS in general (see the <c>Microsoft.AspNetCore.Cors</c> package), apply
+    /// <c>DisableCorsAttribute</c> to this action. If the application depends on the
+    /// <c>Microsoft.AspNetCore.Mvc.ViewFeatures</c> package, apply <c>IgnoreAntiforgeryTokenAttribute</c> to this
+    /// action.
+    /// </para>
+    /// <para>
+    /// <see cref="KuduWebHookAttribute"/> should be used at most once per <see cref="WebHookAttribute.Id"/> in a
+    /// WebHook application.
+    /// </para>
+    /// </remarks>
     public class KuduWebHookAttribute : WebHookAttribute
     {
         /// <summary>
-        /// <para>
-        /// Instantiates a new <see cref="KuduWebHookAttribute"/> indicating the associated action is a Kudu
-        /// WebHook endpoint.
-        /// </para>
-        /// <para>The signature of the action should be:
-        /// <code>
-        /// Task{IActionResult} ActionName(string id, TData data)
-        /// </code>
-        /// or include the subset of parameters required. <c>TData</c> must be compatible with expected requests e.g.
-        /// <see cref="Newtonsoft.Json.Linq.JObject"/> or <see cref="KuduNotification"/>.
-        /// </para>
-        /// <para>This constructor should usually be used at most once in a WebHook application.</para>
+        /// Instantiates a new <see cref="KuduWebHookAttribute"/> indicating the associated action is a Kudu WebHook
+        /// endpoint.
         /// </summary>
         public KuduWebHookAttribute()
             : base(KuduConstants.ReceiverName)

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.MailChimp/Extensions/MailChimpMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.MailChimp/Extensions/MailChimpMvcBuilderExtensions.cs
@@ -14,7 +14,17 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class MailChimpMvcBuilderExtensions
     {
         /// <summary>
-        /// Add MailChimp WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add MailChimp WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://developer.mailchimp.com/documentation/mailchimp/guides/about-webhooks/"/> for additional
+        /// details about MailChimp WebHook requests.
+        /// </para>
+        /// <para>
+        /// The '<c>WebHooks:MailChimp:SecretKey:default</c>' configuration value contains the secret key for MailChimp
+        /// WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/mailchimp?code={secret key}</c>'.
+        /// '<c>WebHooks:MailChimp:SecretKey:{id}</c>' configuration values contain secret keys for MailChimp WebHook
+        /// URIs of the form '<c>https://{host}/api/webhooks/incoming/mailchimp/{id}?code={secret key}</c>'.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.MailChimp/Extensions/MailChimpMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.MailChimp/Extensions/MailChimpMvcCoreBuilderExtensions.cs
@@ -14,7 +14,17 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class MailChimpMvcCoreBuilderExtensions
     {
         /// <summary>
-        /// Add MailChimp WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add MailChimp WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://developer.mailchimp.com/documentation/mailchimp/guides/about-webhooks/"/> for additional
+        /// details about MailChimp WebHook requests.
+        /// </para>
+        /// <para>
+        /// The '<c>WebHooks:MailChimp:SecretKey:default</c>' configuration value contains the secret key for MailChimp
+        /// WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/mailchimp</c>'.
+        /// '<c>WebHooks:MailChimp:SecretKey:{id}</c>' configuration values contain secret keys for MailChimp WebHook
+        /// URIs of the form '<c>https://{host}/api/webhooks/incoming/mailchimp/{id}</c>'.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcCoreBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.MailChimp/MailChimpWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.MailChimp/MailChimpWebHookAttribute.cs
@@ -10,27 +10,37 @@ namespace Microsoft.AspNetCore.WebHooks
     /// for the action.
     /// </para>
     /// <para>
+    /// The signature of the action should be:
+    /// <code>
+    /// Task{IActionResult} ActionName(string id, string @event, TData data)
+    /// </code>
+    /// or include the subset of parameters required. <c>TData</c> must be compatible with expected requests e.g.
+    /// <see cref="Http.IFormCollection"/>.
+    /// </para>
+    /// <para>
     /// An example MailChimp WebHook URI is
-    /// '<c>https://&lt;host&gt;/api/webhooks/incoming/mailchimp/{id}?code=83699ec7c1d794c0c780e49a5c72972590571fd8</c>'.
-    /// See <see href="http://developer.mailchimp.com/documentation/mailchimp/guides/about-webhooks/"/> for additional
+    /// '<c>https://{host}/api/webhooks/incoming/mailchimp/{id}?code=83699ec7c1d794c0c780e49a5c72972590571fd8</c>'.
+    /// See <see href="https://developer.mailchimp.com/documentation/mailchimp/guides/about-webhooks/"/> for additional
     /// details about MailChimp WebHook requests.
     /// </para>
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If the application enables CORS in general (see the <c>Microsoft.AspNetCore.Cors</c> package), apply
+    /// <c>DisableCorsAttribute</c> to this action. If the application depends on the
+    /// <c>Microsoft.AspNetCore.Mvc.ViewFeatures</c> package, apply <c>IgnoreAntiforgeryTokenAttribute</c> to this
+    /// action.
+    /// </para>
+    /// <para>
+    /// <see cref="MailChimpWebHookAttribute"/> should be used at most once per <see cref="WebHookAttribute.Id"/> in a
+    /// WebHook application.
+    /// </para>
+    /// </remarks>
     public class MailChimpWebHookAttribute : WebHookAttribute
     {
         /// <summary>
-        /// <para>
         /// Instantiates a new <see cref="MailChimpWebHookAttribute"/> indicating the associated action is a MailChimp
         /// WebHook endpoint.
-        /// </para>
-        /// <para>The signature of the action should be:
-        /// <code>
-        /// Task{IActionResult} ActionName(string id, TData data)
-        /// </code>
-        /// or include the subset of parameters required. <c>TData</c> must be compatible with expected requests e.g.
-        /// <see cref="Http.IFormCollection"/>.
-        /// </para>
-        /// <para>This constructor should usually be used at most once in a WebHook application.</para>
         /// </summary>
         public MailChimpWebHookAttribute()
             : base(MailChimpConstants.ReceiverName)

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Pusher/Extensions/PusherMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Pusher/Extensions/PusherMvcBuilderExtensions.cs
@@ -14,7 +14,17 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class PusherMvcBuilderExtensions
     {
         /// <summary>
-        /// Add Pusher WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add Pusher WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://pusher.com/docs/webhooks"/> for additional details about Pusher WebHook requests.
+        /// </para>
+        /// <para>
+        /// '<c>WebHooks:Pusher:SecretKey:default:{application key}</c>' configuration values contain secret keys for
+        /// Pusher WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/pusher</c>'.
+        /// '<c>WebHooks:Pusher:SecretKey:{id}:{application key}</c>' configuration values contain secret keys for
+        /// Pusher WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/pusher/{id}</c>'. Users optionally
+        /// provide <c>{id}</c> values while Pusher defines the <c>{application key}</c> / secret key pairs.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Pusher/Extensions/PusherMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Pusher/Extensions/PusherMvcCoreBuilderExtensions.cs
@@ -14,7 +14,17 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class PusherMvcCoreBuilderExtensions
     {
         /// <summary>
-        /// Add Pusher WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add Pusher WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://pusher.com/docs/webhooks"/> for additional details about Pusher WebHook requests.
+        /// </para>
+        /// <para>
+        /// '<c>WebHooks:Pusher:SecretKey:default:{application key}</c>' configuration values contain secret keys for
+        /// Pusher WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/pusher</c>'.
+        /// '<c>WebHooks:Pusher:SecretKey:{id}:{application key}</c>' configuration values contain secret keys for
+        /// Pusher WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/pusher/{id}</c>'. Users optionally
+        /// provide <c>{id}</c> values while Pusher defines the <c>{application key}</c> / secret key pairs.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcCoreBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Pusher/PusherWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Pusher/PusherWebHookAttribute.cs
@@ -10,34 +10,35 @@ namespace Microsoft.AspNetCore.WebHooks
     /// the action.
     /// </para>
     /// <para>
-    /// The '<c>MS_WebHookReceiverSecret_Pusher</c>' configuration value contains a semicolon-separated list of values
-    /// of the form '<c>appKey_secretKey</c>'. The underscore-separated strings are application key / secret key pairs
-    /// defined in Pusher. An example configuration value containing two application key / secret key pairs is
-    /// '<c>47e5a8cd8f6bb492252a_42fef23870926753d345; ba3af8f38f3be37d476a_9eb6d047bb5465a43cb2</c>'. An example
-    /// configuration value containing a default with two application key / secret key pairs and an addition id with
-    /// one pair is:
-    /// '<c>47e5a8cd8f6bb492252a_42fef23870926753d345; ba3af8f38f3be37d476a_9eb6d047bb5465a43cb2, id1=39edd0bdb9834a588e98_16e92a1c11b6b2f43df7</c>'
+    /// The signature of the action should be:
+    /// <code>
+    /// Task{IActionResult} ActionName(string id, string[] events, TData data)
+    /// </code>
+    /// or include the subset of parameters required. <c>TData</c> must be compatible with expected requests e.g.
+    /// <see cref="Newtonsoft.Json.Linq.JObject"/> or <see cref="PusherNotifications"/>.
     /// </para>
     /// <para>
-    /// An example Pusher WebHook URI is '<c>https://&lt;host&gt;/api/webhooks/incoming/pusher/{id}</c>'. See
+    /// An example Pusher WebHook URI is '<c>https://{host}/api/webhooks/incoming/pusher/{id}</c>'. See
     /// <see href="https://pusher.com/docs/webhooks"/> for additional details about Pusher WebHook requests.
     /// </para>
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If the application enables CORS in general (see the <c>Microsoft.AspNetCore.Cors</c> package), apply
+    /// <c>DisableCorsAttribute</c> to this action. If the application depends on the
+    /// <c>Microsoft.AspNetCore.Mvc.ViewFeatures</c> package, apply <c>IgnoreAntiforgeryTokenAttribute</c> to this
+    /// action.
+    /// </para>
+    /// <para>
+    /// <see cref="PusherWebHookAttribute"/> should be used at most once per <see cref="WebHookAttribute.Id"/> in a
+    /// WebHook application.
+    /// </para>
+    /// </remarks>
     public class PusherWebHookAttribute : WebHookAttribute
     {
         /// <summary>
-        /// <para>
         /// Instantiates a new <see cref="PusherWebHookAttribute"/> indicating the associated action is a Pusher
         /// WebHook endpoint.
-        /// </para>
-        /// <para>The signature of the action should be:
-        /// <code>
-        /// Task{IActionResult} ActionName(string id, TData data)
-        /// </code>
-        /// or include the subset of parameters required. <c>TData</c> must be compatible with expected requests e.g.
-        /// <see cref="Newtonsoft.Json.Linq.JObject"/> or <see cref="PusherNotifications"/>.
-        /// </para>
-        /// <para>This constructor should usually be used at most once in a WebHook application.</para>
         /// </summary>
         public PusherWebHookAttribute()
             : base(PusherConstants.ReceiverName)

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/Extensions/SalesforceMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/Extensions/SalesforceMvcBuilderExtensions.cs
@@ -14,7 +14,19 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class SalesforceMvcBuilderExtensions
     {
         /// <summary>
-        /// Add Salesforce WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add Salesforce WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://go.microsoft.com/fwlink/?linkid=838587"/> for additional details about Salesforce
+        /// WebHook requests.
+        /// </para>
+        /// <para>
+        /// The '<c>WebHooks:SalesforceSoap:SecretKey:default</c>' configuration value contains the secret key for
+        /// Salesforce WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/sfsoap</c>'.
+        /// '<c>WebHooks:SalesforceSoap:SecretKey:{id}</c>' configuration values contain secret keys for Salesforce
+        /// WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/sfsoap/{id}</c>'. Secret keys are
+        /// Salesforce Organization IDs and can be found at <see href="https://www.salesforce.com"/> under
+        /// <c>Setup | Company Profile | Company Information</c>.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/Extensions/SalesforceMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/Extensions/SalesforceMvcCoreBuilderExtensions.cs
@@ -14,7 +14,19 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class SalesforceMvcCoreBuilderExtensions
     {
         /// <summary>
-        /// Add Salesforce WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add Salesforce WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://go.microsoft.com/fwlink/?linkid=838587"/> for additional details about Salesforce
+        /// WebHook requests.
+        /// </para>
+        /// <para>
+        /// The '<c>WebHooks:SalesforceSoap:SecretKey:default</c>' configuration value contains the secret key for
+        /// Salesforce WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/sfsoap</c>'.
+        /// '<c>WebHooks:SalesforceSoap:SecretKey:{id}</c>' configuration values contain secret keys for Salesforce
+        /// WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/sfsoap/{id}</c>'. Secret keys are
+        /// Salesforce Organization IDs and can be found at <see href="https://www.salesforce.com"/> under
+        /// <c>Setup | Company Profile | Company Information</c>.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcCoreBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/SalesforceWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/SalesforceWebHookAttribute.cs
@@ -24,14 +24,23 @@ namespace Microsoft.AspNetCore.WebHooks
     /// WebHook requests.
     /// </para>
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If the application enables CORS in general (see the <c>Microsoft.AspNetCore.Cors</c> package), apply
+    /// <c>DisableCorsAttribute</c> to this action. If the application depends on the
+    /// <c>Microsoft.AspNetCore.Mvc.ViewFeatures</c> package, apply <c>IgnoreAntiforgeryTokenAttribute</c> to this
+    /// action.
+    /// </para>
+    /// <para>
+    /// <see cref="SalesforceWebHookAttribute"/> should be used at most once per <see cref="WebHookAttribute.Id"/> in a
+    /// WebHook application.
+    /// </para>
+    /// </remarks>
     public class SalesforceWebHookAttribute : WebHookAttribute
     {
         /// <summary>
-        /// <para>
         /// Instantiates a new <see cref="SalesforceWebHookAttribute"/> indicating the associated action is a
         /// Salesforce WebHook endpoint.
-        /// </para>
-        /// <para>This constructor should usually be used at most once in a WebHook application.</para>
         /// </summary>
         public SalesforceWebHookAttribute()
             : base(SalesforceConstants.ReceiverName)

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/Extensions/SlackMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/Extensions/SlackMvcBuilderExtensions.cs
@@ -14,7 +14,17 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class SlackMvcBuilderExtensions
     {
         /// <summary>
-        /// Add Slack WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add Slack WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://api.slack.com/custom-integrations/outgoing-webhooks"/> for additional details about
+        /// Slack WebHook requests.
+        /// </para>
+        /// <para>
+        /// The '<c>WebHooks:Slack:SecretKey:default</c>' configuration value contains the secret key for Slack WebHook
+        /// URIs of the form '<c>https://{host}/api/webhooks/incoming/slack</c>'.
+        /// '<c>WebHooks:Slack:SecretKey:{id}</c>' configuration values contain secret keys for Slack WebHook URIs of
+        /// the form '<c>https://{host}/api/webhooks/incoming/slack/{id}</c>'.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/Extensions/SlackMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/Extensions/SlackMvcCoreBuilderExtensions.cs
@@ -14,7 +14,17 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class SlackMvcCoreBuilderExtensions
     {
         /// <summary>
-        /// Add Slack WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add Slack WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://api.slack.com/custom-integrations/outgoing-webhooks"/> for additional details about
+        /// Slack WebHook requests.
+        /// </para>
+        /// <para>
+        /// The '<c>WebHooks:Slack:SecretKey:default</c>' configuration value contains the secret key for Slack WebHook
+        /// URIs of the form '<c>https://{host}/api/webhooks/incoming/slack</c>'.
+        /// '<c>WebHooks:Slack:SecretKey:{id}</c>' configuration values contain secret keys for Slack WebHook URIs of
+        /// the form '<c>https://{host}/api/webhooks/incoming/slack/{id}</c>'.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcCoreBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/SlackWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/SlackWebHookAttribute.cs
@@ -13,10 +13,11 @@ namespace Microsoft.AspNetCore.WebHooks
     /// <para>
     /// An <see cref="Attribute"/> indicating the associated action is a Slack WebHook endpoint. Specifies the optional
     /// <see cref="WebHookAttribute.Id"/>.  Also adds a <see cref="Filters.WebHookReceiverExistsFilter"/> for the
-    /// action and delegates its <see cref="IResultFilter"/> implementation to a <see cref="ProducesAttribute"/>,
-    /// indicating the action produces JSON-formatted responses.
+    /// action and delegates its <see cref="IResultFilter"/> <see cref="IApiResponseMetadataProvider"/> implementations
+    /// to a <see cref="ProducesAttribute"/>, indicating the action produces JSON-formatted responses.
     /// </para>
-    /// <para>The signature of the action should be:
+    /// <para>
+    /// The signature of the action should be:
     /// <code>
     /// Task{TResult} ActionName(string id, string @event, string subtext, TData data)
     /// </code>
@@ -25,24 +26,34 @@ namespace Microsoft.AspNetCore.WebHooks
     /// <see cref="SlackSlashResponse"/>, or an <see cref="IActionResult"/> implementation.
     /// </para>
     /// <para>
-    /// The '<c>MS_WebHookReceiverSecret_Slack</c>' configuration value contains Slack shared-private security tokens.
-    /// </para>
-    /// <para>
-    /// An example Slack WebHook URI is '<c>https://&lt;host&gt;/api/webhooks/incoming/slack/{id}</c>'.
+    /// An example Slack WebHook URI is '<c>https://{host}/api/webhooks/incoming/slack/{id}</c>'.
     /// See <see href="https://api.slack.com/custom-integrations/outgoing-webhooks"/> for additional details about
     /// Slack WebHook requests.
     /// </para>
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If the application enables CORS in general (see the <c>Microsoft.AspNetCore.Cors</c> package), apply
+    /// <c>DisableCorsAttribute</c> to this action. If the application depends on the
+    /// <c>Microsoft.AspNetCore.Mvc.ViewFeatures</c> package, apply <c>IgnoreAntiforgeryTokenAttribute</c> to this
+    /// action.
+    /// </para>
+    /// <para>
+    /// <see cref="SlackWebHookAttribute"/> should be used at most once per <see cref="WebHookAttribute.Id"/> in a
+    /// WebHook application.
+    /// </para>
+    /// <para>
+    /// Implements <see cref="IApiResponseMetadataProvider"/> to provide information to a <see cref="FormatFilter"/>.
+    /// Implements <see cref="IResultFilter"/> for the odd case where no <see cref="FormatFilter"/> applies.
+    /// </para>
+    /// </remarks>
     public class SlackWebHookAttribute : WebHookAttribute, IResultFilter, IApiResponseMetadataProvider
     {
         private static readonly ProducesAttribute Produces = new ProducesAttribute("application/json");
 
         /// <summary>
-        /// <para>
-        /// Instantiates a new <see cref="SlackWebHookAttribute"/> indicating the associated action is a
-        /// Slack WebHook endpoint.
-        /// </para>
-        /// <para>This constructor should usually be used at most once in a WebHook application.</para>
+        /// Instantiates a new <see cref="SlackWebHookAttribute"/> indicating the associated action is a Slack WebHook
+        /// endpoint.
         /// </summary>
         public SlackWebHookAttribute()
             : base(SlackConstants.ReceiverName)

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Stripe/Extensions/StripeMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Stripe/Extensions/StripeMvcBuilderExtensions.cs
@@ -14,7 +14,20 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class StripeMvcBuilderExtensions
     {
         /// <summary>
-        /// Add Stripe WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add Stripe WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://stripe.com/docs/webhooks"/> for additional details about Stripe WebHook requests. See
+        /// <see href="https://stripe.com/docs/connect/webhooks"/> for additional details about Stripe Connect WebHook
+        /// requests. And, see <see href="https://stripe.com/docs/api/dotnet#events"/> for additional details about
+        /// Stripe WebHook request payloads.
+        /// </para>
+        /// <para>
+        /// The '<c>WebHooks:Stripe:SecretKey:default</c>' configuration value contains the signing secret for Stripe
+        /// WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/stripe</c>'.
+        /// '<c>WebHooks:Stripe:SecretKey:{id}</c>' configuration values contain signing secret for Stripe WebHook URIs
+        /// of the form '<c>https://{host}/api/webhooks/incoming/stripe/{id}</c>'. For details about Stripe signing
+        /// secrets, see <see href="https://stripe.com/docs/webhooks#signatures"/>.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Stripe/Extensions/StripeMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Stripe/Extensions/StripeMvcCoreBuilderExtensions.cs
@@ -14,7 +14,20 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class StripeMvcCoreBuilderExtensions
     {
         /// <summary>
-        /// Add Stripe WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// <para>
+        /// Add Stripe WebHook configuration and services to the specified <paramref name="builder"/>. See
+        /// <see href="https://stripe.com/docs/webhooks"/> for additional details about Stripe WebHook requests. See
+        /// <see href="https://stripe.com/docs/connect/webhooks"/> for additional details about Stripe Connect WebHook
+        /// requests. And, see <see href="https://stripe.com/docs/api/dotnet#events"/> for additional details about
+        /// Stripe WebHook request payloads.
+        /// </para>
+        /// <para>
+        /// The '<c>WebHooks:Stripe:SecretKey:default</c>' configuration value contains the signing secret for Stripe
+        /// WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/stripe</c>'.
+        /// '<c>WebHooks:Stripe:SecretKey:{id}</c>' configuration values contain signing secret for Stripe WebHook URIs
+        /// of the form '<c>https://{host}/api/webhooks/incoming/stripe/{id}</c>'. For details about Stripe signing
+        /// secrets, see <see href="https://stripe.com/docs/webhooks#signatures"/>.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcCoreBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Extensions/WebHookMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Extensions/WebHookMvcBuilderExtensions.cs
@@ -14,7 +14,16 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class WebHookMvcBuilderExtensions
     {
         /// <summary>
+        /// <para>
         /// Add WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// </para>
+        /// <para>
+        /// '<c>WebHooks:{receiver name}:SecretKey:default</c>' configuration values usually contain secret keys for
+        /// WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/{receiver name}</c>' (with a
+        /// <c>?code=...</c> query string for some receivers). '<c>WebHooks:{receiver name}:SecretKey:{id}</c>'
+        /// configuration values usually contain secret keys for WebHook URIs of the form
+        /// '<c>https://{host}/api/webhooks/incoming/{receiver name}/{id}</c>'.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Extensions/WebHookMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Extensions/WebHookMvcCoreBuilderExtensions.cs
@@ -14,7 +14,16 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class WebHookMvcCoreBuilderExtensions
     {
         /// <summary>
+        /// <para>
         /// Add WebHook configuration and services to the specified <paramref name="builder"/>.
+        /// </para>
+        /// <para>
+        /// '<c>WebHooks:{receiver name}:SecretKey:default</c>' configuration values usually contain secret keys for
+        /// WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/{receiver name}</c>' (with a
+        /// <c>?code=...</c> query string for some receivers). '<c>WebHooks:{receiver name}:SecretKey:{id}</c>'
+        /// configuration values usually contain secret keys for WebHook URIs of the form
+        /// '<c>https://{host}/api/webhooks/incoming/{receiver name}/{id}</c>'.
+        /// </para>
         /// </summary>
         /// <param name="builder">The <see cref="IMvcCoreBuilder" /> to configure.</param>
         /// <returns>The <paramref name="builder"/>.</returns>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookVerifyCodeFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookVerifyCodeFilter.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
         /// For WebHook providers with insufficient security considerations, the receiver can require that the WebHook
         /// URI must be an <c>https</c> URI and contain a 'code' query parameter with a value configured for that
         /// particular <c>id</c>. A sample WebHook URI is
-        /// '<c>https://&lt;host&gt;/api/webhooks/incoming/&lt;receiver&gt;?code=83699ec7c1d794c0c780e49a5c72972590571fd8</c>'.
+        /// '<c>https://{host}/api/webhooks/incoming/{receiver name}?code=83699ec7c1d794c0c780e49a5c72972590571fd8</c>'.
         /// The 'code' parameter must be between 32 and 128 characters long.
         /// </summary>
         /// <param name="request">The current <see cref="HttpRequest"/>.</param>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/GeneralWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/GeneralWebHookAttribute.cs
@@ -10,20 +10,34 @@ namespace Microsoft.AspNetCore.WebHooks
 {
     /// <summary>
     /// <para>
-    /// An <see cref="Attribute"/> indicating the associated action is a WebHook endpoint for all enabled
-    /// receivers. Specifies the expected <see cref="BodyType"/>, optional <see cref="EventName"/>, and optional
-    /// <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="Filters.WebHookReceiverExistsFilter"/> for
-    /// the action.
+    /// An <see cref="Attribute"/> indicating the associated action is a WebHook endpoint for all enabled receivers.
+    /// Specifies the expected <see cref="BodyType"/>, optional <see cref="EventName"/>, and optional
+    /// <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="Filters.WebHookReceiverExistsFilter"/> for the
+    /// action.
     /// </para>
-    /// <para>The signature of the action should be:
+    /// <para>
+    /// The signature of the action should be:
     /// <code>
     /// Task{IActionResult} ActionName(string receiverName, string id, string[] events, TData data)
     /// </code>
     /// or the subset of parameters required. <c>TData</c> must be compatible with expected requests.
     /// </para>
+    /// <para>
+    /// An example WebHook URI is '<c>https://{host}/api/webhooks/incoming/{receiver name}/{id}</c>' or
+    /// '<c>https://{host}/api/webhooks/incoming/{receiver name}/{id}?code=94c0c780e49a5c72972590571fd8</c>'.
+    /// </para>
     /// </summary>
     /// <remarks>
-    /// This attribute should usually be used at most once in a WebHook application.
+    /// <para>
+    /// If the application enables CORS in general (see the <c>Microsoft.AspNetCore.Cors</c> package), apply
+    /// <c>DisableCorsAttribute</c> to this action. If the application depends on the
+    /// <c>Microsoft.AspNetCore.Mvc.ViewFeatures</c> package, apply <c>IgnoreAntiforgeryTokenAttribute</c> to this
+    /// action.
+    /// </para>
+    /// <para>
+    /// <see cref="GeneralWebHookAttribute"/> should be used at most once per <see cref="WebHookAttribute.Id"/> and
+    /// <see cref="EventName"/> in a WebHook application.
+    /// </para>
     /// </remarks>
     public class GeneralWebHookAttribute : WebHookAttribute, IWebHookBodyTypeMetadata, IWebHookEventSelectorMetadata
     {

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/IWebHookReceiver.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/IWebHookReceiver.cs
@@ -17,10 +17,10 @@ namespace Microsoft.AspNetCore.WebHooks
         /// </para>
         /// <para>
         /// The name provided here will map to a URI of the form
-        /// '<c>https://&lt;host&gt;/api/webhooks/incoming/&lt;name&gt;</c>'.
+        /// '<c>https://{host}/api/webhooks/incoming/{ReceiverName}</c>'.
         /// </para>
         /// </summary>
-        /// <value>Must not return an empty string.</value>
+        /// <value>Should not return an empty string.</value>
         string ReceiverName { get; }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/WebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/WebHookAttribute.cs
@@ -15,6 +15,18 @@ namespace Microsoft.AspNetCore.WebHooks
     /// required (in most cases) <see cref="ReceiverName"/> and optional <see cref="Id"/>. Also adds a
     /// <see cref="WebHookReceiverExistsFilter"/> for the action.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If the application enables CORS in general (see the <c>Microsoft.AspNetCore.Cors</c> package), apply
+    /// <c>DisableCorsAttribute</c> to this action. If the application depends on the
+    /// <c>Microsoft.AspNetCore.Mvc.ViewFeatures</c> package, apply <c>IgnoreAntiforgeryTokenAttribute</c> to this
+    /// action.
+    /// </para>
+    /// <para>
+    /// Subclasses of <see cref="WebHookAttribute"/> should be used at most once per <see cref="ReceiverName"/> and
+    /// <see cref="Id"/> in a WebHook application. Some subclasses support additional uniqueness constraints.
+    /// </para>
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public abstract class WebHookAttribute : Attribute, IAllowAnonymous, IFilterFactory
     {
@@ -24,23 +36,9 @@ namespace Microsoft.AspNetCore.WebHooks
         {
         }
 
-        // TODO: Move attribute constructors' comments, especially the recommended action signatures, to class level.
-        // TODO:  Do the same for all subclasses. As-is important information is hard to find.
         /// <summary>
-        /// <para>
-        /// Instantiates a new <see cref="WebHookAttribute"/> indicating the associated action is a WebHook
-        /// endpoint for the given <paramref name="receiverName"/>.
-        /// </para>
-        /// <para>The signature of the action should be:
-        /// <code>
-        /// Task{IActionResult} ActionName(string id, string[] events, TData data)
-        /// </code>
-        /// or include the subset of parameters required. <c>TData</c> must be compatible with expected requests.
-        /// </para>
-        /// <para>
-        /// This constructor should usually be used at most once per <paramref name="receiverName"/> name in a WebHook
-        /// application.
-        /// </para>
+        /// Instantiates a new <see cref="WebHookAttribute"/> indicating the associated action is a WebHook endpoint
+        /// for the given <paramref name="receiverName"/>.
         /// </summary>
         /// <param name="receiverName">The name of an available <see cref="IWebHookReceiver"/>.</param>
         protected WebHookAttribute(string receiverName)


### PR DESCRIPTION
- last part of #178
- add information to `Attribute` and `IMvcBuilder` / `IMvcCoreBuilder` extension comments
  - make that info more visible e.g. move `Attribute` details to class level
- remove outdated mentions of `MS_WebHook*` configuration values
- use HTTPS in documentation links