### PR TITLE
Update URLs in .nuspec and README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ AppVeyor: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/aspnet
 
 ASP.NET Web Hooks provide support for sending and receiving WebHooks. 
 
-See [Introducing Microsoft ASP.NET WebHooks Preview](http://blogs.msdn.com/b/webdev/archive/2015/09/04/introducing-microsoft-asp-net-webhooks-preview.aspx) for an introduction.
+See [Introducing Microsoft ASP.NET WebHooks Preview](https://blogs.msdn.com/b/webdev/archive/2015/09/04/introducing-microsoft-asp-net-webhooks-preview.aspx) for an introduction.
 
-See the initial [documentation](http://go.microsoft.com/fwlink/?LinkId=690277) for details.
+See the initial [documentation](https://go.microsoft.com/fwlink/?LinkId=690277) for details.
 
 ### Samples
 - [All Samples](/samples/)
@@ -40,26 +40,26 @@ See the initial [documentation](http://go.microsoft.com/fwlink/?LinkId=690277) f
 
 ### Resources
 * Overview
-  * [Announcement of Microsoft ASP.NET WebHooks Preview](http://blogs.msdn.com/b/webdev/archive/2015/09/04/introducing-microsoft-asp-net-webhooks-preview.aspx)
-  * [Sending WebHooks with ASP.NET WebHooks Preview](http://blogs.msdn.com/b/webdev/archive/2015/09/15/sending-webhooks-with-asp-net-webhooks-preview.aspx)
+  * [Announcement of Microsoft ASP.NET WebHooks Preview](https://blogs.msdn.com/b/webdev/archive/2015/09/04/introducing-microsoft-asp-net-webhooks-preview.aspx)
+  * [Sending WebHooks with ASP.NET WebHooks Preview](https://blogs.msdn.com/b/webdev/archive/2015/09/15/sending-webhooks-with-asp-net-webhooks-preview.aspx)
   * [Announcing ASP.NET WebHooks Release Candidate 1](https://blogs.msdn.microsoft.com/webdev/2016/03/05/announcing-asp-net-webhooks-release-candidate-1/)
 
 * Integration with WebHook Providers
-  * [Integrating with Instagram using ASP.NET WebHooks Preview](http://blogs.msdn.com/b/webdev/archive/2015/09/21/integrating-with-instagram-using-asp-net-webhooks-preview.aspx)
-  * [Integrating with Salesforce using ASP.NET WebHooks Preview](http://blogs.msdn.com/b/webdev/archive/2015/09/07/integrating-with-salesforce-using-asp-net-webhooks-preview.aspx)
-  * [Integrating with Slack Using ASP.NET WebHooks Preview](http://blogs.msdn.com/b/webdev/archive/2015/09/06/integrating-with-slack-using-asp-net-webhooks-preview.aspx)
-  * [Using ASP.NET WebHooks with IFTTT and Zapier to Monitor Twitter and Google Sheets](http://blogs.msdn.com/b/webdev/archive/2015/11/21/using-asp-net-webhooks-with-ifttt-and-zapier-to-monitor-twitter-and-google-sheets.aspx)
-  * [Receive WebHooks from Azure Alerts and Kudu (Azure Web App Deployment)](http://blogs.msdn.com/b/webdev/archive/2015/10/04/receive-webhooks-from-azure-alerts-and-kudu-azure-web-app-deployment.aspx)
-  * [Sending WebHooks with Microsoft Dynamics CRM](http://blogs.msdn.com/b/crm/archive/2016/01/15/sending-webhooks-with-microsoft-dynamics-crm.aspx)
+  * [Integrating with Instagram using ASP.NET WebHooks Preview](https://blogs.msdn.com/b/webdev/archive/2015/09/21/integrating-with-instagram-using-asp-net-webhooks-preview.aspx)
+  * [Integrating with Salesforce using ASP.NET WebHooks Preview](https://blogs.msdn.com/b/webdev/archive/2015/09/07/integrating-with-salesforce-using-asp-net-webhooks-preview.aspx)
+  * [Integrating with Slack Using ASP.NET WebHooks Preview](https://blogs.msdn.com/b/webdev/archive/2015/09/06/integrating-with-slack-using-asp-net-webhooks-preview.aspx)
+  * [Using ASP.NET WebHooks with IFTTT and Zapier to Monitor Twitter and Google Sheets](https://blogs.msdn.com/b/webdev/archive/2015/11/21/using-asp-net-webhooks-with-ifttt-and-zapier-to-monitor-twitter-and-google-sheets.aspx)
+  * [Receive WebHooks from Azure Alerts and Kudu (Azure Web App Deployment)](https://blogs.msdn.com/b/webdev/archive/2015/10/04/receive-webhooks-from-azure-alerts-and-kudu-azure-web-app-deployment.aspx)
+  * [Sending WebHooks with Microsoft Dynamics CRM](https://blogs.msdn.com/b/crm/archive/2016/01/15/sending-webhooks-with-microsoft-dynamics-crm.aspx)
 
 * Tooling
-  * [Announcing the ASP.NET WebHooks Visual Studio Extension Preview](http://blogs.msdn.com/b/webdev/archive/2015/09/29/announcing-the-asp-net-webhooks-visual-studio-extension-preview.aspx)
+  * [Announcing the ASP.NET WebHooks Visual Studio Extension Preview](https://blogs.msdn.com/b/webdev/archive/2015/09/29/announcing-the-asp-net-webhooks-visual-studio-extension-preview.aspx)
 
 * Updates
-  * [Sending ASP.NET WebHooks from Azure WebJobs](http://blogs.msdn.com/b/webdev/archive/2016/01/31/sending-asp-net-webhooks-from-azure-webjobs.aspx)
-  * [New Year Updates to ASP.NET WebHooks Preview Dec 2015](http://blogs.msdn.com/b/webdev/archive/2015/12/31/new-year-updates-to-asp-net-webhooks-preview.aspx)
+  * [Sending ASP.NET WebHooks from Azure WebJobs](https://blogs.msdn.com/b/webdev/archive/2016/01/31/sending-asp-net-webhooks-from-azure-webjobs.aspx)
+  * [New Year Updates to ASP.NET WebHooks Preview Dec 2015](https://blogs.msdn.com/b/webdev/archive/2015/12/31/new-year-updates-to-asp-net-webhooks-preview.aspx)
     * Storing WebHook registrations in SQL
     * Registering WebHook modules with a dependency engine
-  * [Updates to Microsoft ASP.NET WebHooks Preview Nov 2015](http://blogs.msdn.com/b/webdev/archive/2015/11/07/updates-to-microsoft-asp-net-webhooks-preview.aspx)
+  * [Updates to Microsoft ASP.NET WebHooks Preview Nov 2015](https://blogs.msdn.com/b/webdev/archive/2015/11/07/updates-to-microsoft-asp-net-webhooks-preview.aspx)
     * Sending events to *all* users
     * Sending WebHooks scaling up and out using persistent queues  

--- a/samples/MyGetReceiver/WebHooks/MyGetWebHookHandler.cs
+++ b/samples/MyGetReceiver/WebHooks/MyGetWebHookHandler.cs
@@ -6,7 +6,7 @@ namespace MyGetReceiver.WebHooks
 {
     /// <summary>
     /// This handler processes WebHooks from MyGet and leverages the <see cref="MyGetWebHookHandlerBase"/> base handler.
-    /// For details about MyGet WebHooks, please see <c>http://docs.myget.org/docs/reference/webhooks</c>.
+    /// For details about MyGet WebHooks, please see <c>https://docs.myget.org/docs/reference/webhooks</c>.
     /// </summary>
     public class MyGetWebHookHandler : MyGetWebHookHandlerBase
     {

--- a/samples/MyGetReceiver/index.html
+++ b/samples/MyGetReceiver/index.html
@@ -20,7 +20,7 @@
     </p>
 
     <p>
-        Please see <a href="http://docs.myget.org/docs/reference/webhooks">MyGet WebHooks</a>
+        Please see <a href="https://docs.myget.org/docs/reference/webhooks">MyGet WebHooks</a>
         for more information.
     </p>
 </body>

--- a/samples/SalesforceReceiver/index.html
+++ b/samples/SalesforceReceiver/index.html
@@ -19,7 +19,7 @@
     <p>
         For security reasons, the WebHook URI must be an <c>https</c> URI and the '<c>MS_WebHookReceiverSecret_SalesforceSoap</c>'
         application setting must be configured to the Salesforce Organization IDs. The Organizational IDs can be found at
-        <a href="http://www.salesforce.com">Salesforce</a> under <c>Setup | Company Profile | Company Information</c>.
+        <a href="https://www.salesforce.com">Salesforce</a> under <c>Setup | Company Profile | Company Information</c>.
     </p>
     <p>
         Optionally you can use the {id} field to differentiate between multiple WebHooks. You can configure each endpoint by setting

--- a/src/Microsoft.AspNet.WebHooks.Common/Microsoft.AspNet.WebHooks.Common.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Common/Microsoft.AspNet.WebHooks.Common.nuspec
@@ -6,9 +6,9 @@
     <title>Microsoft ASP.NET WebHooks Common Module</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
       This package provides common functionality for sending and receiving WebHooks using ASP.NET.

--- a/src/Microsoft.AspNet.WebHooks.Custom.Api/Microsoft.AspNet.WebHooks.Custom.Api.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Custom.Api/Microsoft.AspNet.WebHooks.Custom.Api.nuspec
@@ -6,9 +6,9 @@
     <title>Microsoft ASP.NET Custom WebHooks Web API Module</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
       This package contains a set of ASP.NET Web API Controllers for managing your custom WebHooks filters and registrations through a REST-style interface.

--- a/src/Microsoft.AspNet.WebHooks.Custom.AzureStorage/Microsoft.AspNet.WebHooks.Custom.AzureStorage.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Custom.AzureStorage/Microsoft.AspNet.WebHooks.Custom.AzureStorage.nuspec
@@ -6,9 +6,9 @@
     <title>Microsoft ASP.NET Custom WebHooks Azure Storage Module</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
       This package provides support for persisting your custom WebHooks registrations in Microsoft Azure Table Storage.

--- a/src/Microsoft.AspNet.WebHooks.Custom.AzureStorage/Readme.txt
+++ b/src/Microsoft.AspNet.WebHooks.Custom.AzureStorage/Readme.txt
@@ -6,13 +6,13 @@ To set up Table Storage, you must first configure a connection string with the n
 
 For test and development, you can use the local Azure Storage Emulator, which comes as part of the Microsoft Azure SDK.
 To download the latest Microsoft Azure SDK for Visual Studio, please see 'https://azure.microsoft.com/en-us/downloads/'.
-A connection string using the local emulator looks like this: 
+A connection string using the local emulator looks like this:
 
   <add name="MS_AzureStoreConnectionString" connectionString="UseDevelopmentStorage=true;" />
 
-For deployment, you can get a connection string through the Azure Portal at 'https://portal.azure.com'. If you don't 
-already have an Azure account, then you can get one at 'http://azure.com'.
+For deployment, you can get a connection string through the Azure Portal at 'https://portal.azure.com'. If you don't
+already have an Azure account, then you can get one at 'https://azure.com'.
 
 For more information about Azure Table Storage, please see 'https://azure.microsoft.com/en-us/documentation/articles/storage-dotnet-how-to-use-tables/'.
 
-For more information about Microsoft ASP.NET WebHooks, please see 'http://go.microsoft.com/fwlink/?LinkId=690277'.
+For more information about Microsoft ASP.NET WebHooks, please see 'https://go.microsoft.com/fwlink/?LinkId=690277'.

--- a/src/Microsoft.AspNet.WebHooks.Custom.Mvc/Microsoft.AspNet.WebHooks.Custom.Mvc.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Custom.Mvc/Microsoft.AspNet.WebHooks.Custom.Mvc.nuspec
@@ -6,9 +6,9 @@
     <title>Microsoft ASP.NET Custom WebHooks MVC Module</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
       This package exposes helpers for managing and triggering your custom WebHooks from within ASP.NET MVC Controllers.

--- a/src/Microsoft.AspNet.WebHooks.Custom.SqlStorage/Microsoft.AspNet.WebHooks.Custom.SqlStorage.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Custom.SqlStorage/Microsoft.AspNet.WebHooks.Custom.SqlStorage.nuspec
@@ -6,9 +6,9 @@
     <title>Microsoft ASP.NET Custom WebHooks SQL Module</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://www.asp.net/</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://www.asp.net/</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
       This package provides support for persisting your custom WebHooks registrations in a SQL database.

--- a/src/Microsoft.AspNet.WebHooks.Custom.SqlStorage/Readme.txt
+++ b/src/Microsoft.AspNet.WebHooks.Custom.SqlStorage/Readme.txt
@@ -1,15 +1,15 @@
 ﻿Microsoft ASP.NET Custom WebHooks SQL Module
 --------------------------------------------
 
-This package provides support for persisting your custom WebHook registrations in a SQL database. 
+This package provides support for persisting your custom WebHook registrations in a SQL database.
 To set up the SQL DB you must first configure a connection string with the name 'MS_SqlStoreConnectionString',
 for example:
 
-  <add name="MS_SqlStoreConnectionString" 
-    connectionString="Data Source=(LocalDb)\MSSQLLocalDB;Initial Catalog=WebHooks-20151029053732;Integrated Security=True" 
+  <add name="MS_SqlStoreConnectionString"
+    connectionString="Data Source=(LocalDb)\MSSQLLocalDB;Initial Catalog=WebHooks-20151029053732;Integrated Security=True"
     providerName="System.Data.SqlClient" />
 
-To create and initialize the DB, use code migrations as follows: Open the 'Package Manager Console' from the 
+To create and initialize the DB, use code migrations as follows: Open the 'Package Manager Console' from the
 'Tools\Nuget Package Manager' menu and type these three lines one after another:
 
   Enable-Migrations -ContextAssemblyName Microsoft.AspNet.WebHooks.Custom.SqlStorage
@@ -20,4 +20,4 @@ That should create a DB (if it doesn't already exist) and update it to match the
 
 For more information about Entity Framework Code Migrations, please see 'https://msdn.microsoft.com/en-us/data/jj591621.aspx'.
 
-For more information about Microsoft ASP.NET WebHooks, please see 'http://go.microsoft.com/fwlink/?LinkId=690277'.
+For more information about Microsoft ASP.NET WebHooks, please see 'https://go.microsoft.com/fwlink/?LinkId=690277'.

--- a/src/Microsoft.AspNet.WebHooks.Custom/Microsoft.AspNet.WebHooks.Custom.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Custom/Microsoft.AspNet.WebHooks.Custom.nuspec
@@ -6,9 +6,9 @@
     <title>Microsoft ASP.NET Custom WebHooks Module</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
       This package provides functionality for adding your own custom WebHook support to your ASP.NET project. The functionality enables users to register WebHooks using a simple pub/sub model, and for your code to send WebHooks to registered receivers with matching WebHook registrations.

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Azure/Microsoft.AspNet.WebHooks.Receivers.Azure.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Azure/Microsoft.AspNet.WebHooks.Receivers.Azure.nuspec
@@ -6,12 +6,14 @@
     <title>Microsoft ASP.NET WebHooks Receiver for Azure WebHooks.</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
-      This package provides support for receiving WebHooks from Kudu (Azure Web App Deployment) and Azure Alerts. For information about Kudu WebHooks, see "https://github.com/projectkudu/kudu/wiki/Web-hooks" and for Azure Alerts, see "https://azure.microsoft.com/en-us/documentation/articles/insights-webhooks-alerts/".
+      This package provides support for receiving WebHooks from Kudu (Azure Web App Deployment) and Azure Alerts. For
+      information about Kudu WebHooks, see https://github.com/projectkudu/kudu/wiki/Web-hooks and for Azure Alerts, see
+      https://azure.microsoft.com/en-us/documentation/articles/insights-webhooks-alerts/.
     </description>
     <summary>
       This package provides support for receiving WebHooks from Kudu (Azure Web App Deployment) and Azure Alerts.

--- a/src/Microsoft.AspNet.WebHooks.Receivers.BitBucket/Microsoft.AspNet.WebHooks.Receivers.BitBucket.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.BitBucket/Microsoft.AspNet.WebHooks.Receivers.BitBucket.nuspec
@@ -6,11 +6,14 @@
     <title>Microsoft ASP.NET WebHooks Receiver for Bitbucket</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <description>This package provides support for receiving WebHooks from Bitbucket. For information about Bitbucket WebHooks, see "https://confluence.atlassian.com/bitbucket/manage-webhooks-735643732.html".</description>
+    <description>
+      This package provides support for receiving WebHooks from Bitbucket. For information about Bitbucket WebHooks,
+      see https://confluence.atlassian.com/bitbucket/manage-webhooks-735643732.html.
+    </description>
     <releaseNotes></releaseNotes>
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
     <tags>Microsoft AspNet WebApi AspNetWebApi WebHooks Bitbucket</tags>

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Custom/Microsoft.AspNet.WebHooks.Receivers.Custom.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Custom/Microsoft.AspNet.WebHooks.Receivers.Custom.nuspec
@@ -6,9 +6,9 @@
     <title>Microsoft ASP.NET WebHooks Receiver for custom WebHooks.</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
       This package provides support for receiving custom WebHooks from ASP.NET WebHooks implementations.

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Dropbox/Microsoft.AspNet.WebHooks.Receivers.Dropbox.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Dropbox/Microsoft.AspNet.WebHooks.Receivers.Dropbox.nuspec
@@ -6,12 +6,13 @@
     <title>Microsoft ASP.NET WebHooks Receiver for Dropbox</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
-      This package provides support for receiving WebHooks from Dropbox. For information about Dropbox WebHooks, see "https://www.dropbox.com/developers/webhooks/docs".
+      This package provides support for receiving WebHooks from Dropbox. For information about Dropbox WebHooks, see
+      https://www.dropbox.com/developers/webhooks/docs.
     </description>
     <releaseNotes></releaseNotes>
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>

--- a/src/Microsoft.AspNet.WebHooks.Receivers.DynamicsCRM/Extensions/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.DynamicsCRM/Extensions/HttpConfigurationExtensions.cs
@@ -19,7 +19,7 @@ namespace System.Web.Http
         /// same value as configured in the '<c>MS_WebHookReceiverSecret_DynamicsCRM</c>' application setting, optionally using IDs
         /// to differentiate between multiple WebHooks, for example '<c>secret0, id1=secret1, id2=secret2</c>'.
         /// The 'code' parameter must be between 32 and 128 characters long.
-        /// For details about Microsoft Dynamics CRM WebHooks, see <c>http://go.microsoft.com/fwlink/?LinkId=722218</c>.
+        /// For details about Microsoft Dynamics CRM WebHooks, see <c>https://go.microsoft.com/fwlink/?LinkId=722218</c>.
         /// </summary>
         /// <param name="config">The current <see cref="HttpConfiguration"/>config.</param>
         public static void InitializeReceiveDynamicsCrmWebHooks(this HttpConfiguration config)

--- a/src/Microsoft.AspNet.WebHooks.Receivers.DynamicsCRM/Microsoft.AspNet.WebHooks.Receivers.DynamicsCRM.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.DynamicsCRM/Microsoft.AspNet.WebHooks.Receivers.DynamicsCRM.nuspec
@@ -6,12 +6,13 @@
     <title>Microsoft ASP.NET WebHooks Receiver for Microsoft Dynamics CRM</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
-      This package provides support for receiving WebHooks from Microsoft Dynamics CRM. For information about Microsoft Dynamics CRM WebHooks, see "http://go.microsoft.com/fwlink/?LinkId=722218".
+      This package provides support for receiving WebHooks from Microsoft Dynamics CRM. For information about Microsoft
+      Dynamics CRM WebHooks, see https://go.microsoft.com/fwlink/?LinkId=722218.
     </description>
     <releaseNotes></releaseNotes>
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>

--- a/src/Microsoft.AspNet.WebHooks.Receivers.DynamicsCRM/WebHooks/DynamicsCrmWebHookReceiver.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.DynamicsCRM/WebHooks/DynamicsCrmWebHookReceiver.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.WebHooks
     /// same value as configured in the '<c>MS_WebHookReceiverSecret_DynamicsCRM</c>' application setting, optionally using IDs
     /// to differentiate between multiple WebHooks, for example '<c>secret0, id1=secret1, id2=secret2</c>'.
     /// The 'code' parameter must be between 32 and 128 characters long.
-    /// For details about Microsoft Dynamics CRM WebHooks, see <c>http://go.microsoft.com/fwlink/?LinkId=722218</c>.
+    /// For details about Microsoft Dynamics CRM WebHooks, see <c>https://go.microsoft.com/fwlink/?LinkId=722218</c>.
     /// </summary>
     public class DynamicsCrmWebHookReceiver : WebHookReceiver
     {

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Generic/Microsoft.AspNet.WebHooks.Receivers.Generic.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Generic/Microsoft.AspNet.WebHooks.Receivers.Generic.nuspec
@@ -6,12 +6,14 @@
     <title>Microsoft ASP.NET WebHooks Receiver for Generic WebHooks</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
-      This package provides support for receiving generic WebHooks with no special validation logic or security requirements. This can for example be used to receive WebHooks from IFTTT's Maker Channel or a Zapier WebHooks Action.
+      This package provides support for receiving generic WebHooks with no special validation logic or security
+      requirements. This can for example be used to receive WebHooks from IFTTT's Maker Channel or a Zapier WebHooks
+      Action.
     </description>
     <releaseNotes></releaseNotes>
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>

--- a/src/Microsoft.AspNet.WebHooks.Receivers.GitHub/Microsoft.AspNet.WebHooks.Receivers.GitHub.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.GitHub/Microsoft.AspNet.WebHooks.Receivers.GitHub.nuspec
@@ -6,12 +6,13 @@
     <title>Microsoft ASP.NET WebHooks Receiver for GitHub</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
-      This package provides support for receiving WebHooks from GitHub. For information about GitHub WebHooks, see "https://developer.github.com/webhooks/".
+      This package provides support for receiving WebHooks from GitHub. For information about GitHub WebHooks, see
+      https://developer.github.com/webhooks/.
     </description>
     <releaseNotes></releaseNotes>
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Instagram/Microsoft.AspNet.WebHooks.Receivers.Instagram.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Instagram/Microsoft.AspNet.WebHooks.Receivers.Instagram.nuspec
@@ -6,12 +6,13 @@
     <title>Microsoft ASP.NET WebHooks Receiver for Instagram</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
-      This package provides support for receiving WebHooks from Instagram. For information about Instagram WebHooks, see "https://www.instagram.com/developer/subscriptions/".
+      This package provides support for receiving WebHooks from Instagram. For information about Instagram WebHooks,
+      see https://www.instagram.com/developer/subscriptions/.
     </description>
     <releaseNotes></releaseNotes>
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>

--- a/src/Microsoft.AspNet.WebHooks.Receivers.MailChimp/Microsoft.AspNet.WebHooks.Receivers.MailChimp.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.MailChimp/Microsoft.AspNet.WebHooks.Receivers.MailChimp.nuspec
@@ -6,12 +6,13 @@
     <title>Microsoft ASP.NET WebHooks Receiver for MailChimp</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
-      This package provides support for receiving WebHooks from MailChimp. For information about MailChimp WebHooks, see "https://apidocs.mailchimp.com/webhooks/".
+      This package provides support for receiving WebHooks from MailChimp. For information about MailChimp WebHooks,
+      see https://developer.mailchimp.com/documentation/mailchimp/guides/about-webhooks/.
     </description>
     <releaseNotes></releaseNotes>
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>

--- a/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Extensions/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Extensions/HttpConfigurationExtensions.cs
@@ -20,7 +20,7 @@ namespace System.Web.Http
         /// For security reasons the WebHook URI must be an <c>https</c> URI and contain a 'code' query parameter with the
         /// same value as configured in the '<c>MS_WebHookReceiverSecret_MyGet</c>' application setting.
         /// The 'code' parameter must be between 32 and 128 characters long.
-        /// For details about MyGet WebHooks, see <c>http://docs.myget.org/docs/reference/webhooks</c>.
+        /// For details about MyGet WebHooks, see <c>https://docs.myget.org/docs/reference/webhooks</c>.
         /// </summary>
         /// <param name="config">The current <see cref="HttpConfiguration"/>config.</param>
         public static void InitializeReceiveMyGetWebHooks(this HttpConfiguration config)

--- a/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Handlers/MyGetWebHookHandlerBase.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Handlers/MyGetWebHookHandlerBase.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNet.WebHooks
 {
     /// <summary>
     /// Provides a base <see cref="IWebHookHandler" /> implementation which can be used to for handling MyGet WebHook using strongly-typed
-    /// payloads. For details about MyGet WebHooks, see <c>http://docs.myget.org/docs/reference/webhooks</c>.
+    /// payloads. For details about MyGet WebHooks, see <c>https://docs.myget.org/docs/reference/webhooks</c>.
     /// </summary>
     public abstract class MyGetWebHookHandlerBase : WebHookHandler
     {

--- a/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Microsoft.AspNet.WebHooks.Receivers.MyGet.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Microsoft.AspNet.WebHooks.Receivers.MyGet.nuspec
@@ -6,12 +6,14 @@
     <title>Microsoft ASP.NET WebHooks Receiver for MyGet</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
-      This package provides support for receiving WebHooks from MyGet. For information about MyGet WebHooks, see "http://docs.myget.org/docs/reference/webhooks". Implement "MyGetWebHookHandlerBase" to work with strong-typed webhook payloads.
+      This package provides support for receiving WebHooks from MyGet. For information about MyGet WebHooks, see
+      https://docs.myget.org/docs/reference/webhooks. Implement "MyGetWebHookHandlerBase" to work with strong-typed
+      WebHook payloads.
     </description>
     <releaseNotes></releaseNotes>
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>

--- a/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Payloads/BuildFinishedPayload.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Payloads/BuildFinishedPayload.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNet.WebHooks.Payloads
 {
     /// <summary>
     /// Payload sent when a build has finished.
-    /// See <c>http://docs.myget.org/docs/reference/webhooks</c> for details.
+    /// See <c>https://docs.myget.org/docs/reference/webhooks</c> for details.
     /// </summary>
     public class BuildFinishedPayload
     {

--- a/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Payloads/BuildQueuedPayload.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Payloads/BuildQueuedPayload.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNet.WebHooks.Payloads
 {
     /// <summary>
     /// Payload sent when a build is queued.
-    /// See <c>http://docs.myget.org/docs/reference/webhooks</c> for details.
+    /// See <c>https://docs.myget.org/docs/reference/webhooks</c> for details.
     /// </summary>
     public class BuildQueuedPayload
     {

--- a/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Payloads/BuildStartedPayload.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Payloads/BuildStartedPayload.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNet.WebHooks.Payloads
 {
     /// <summary>
     /// Payload sent when a build is started.
-    /// See <c>http://docs.myget.org/docs/reference/webhooks</c> for details.
+    /// See <c>https://docs.myget.org/docs/reference/webhooks</c> for details.
     /// </summary>
     public class BuildStartedPayload
     {

--- a/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Payloads/Package.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Payloads/Package.cs
@@ -5,7 +5,7 @@ namespace Microsoft.AspNet.WebHooks.Payloads
 {
     /// <summary>
     /// Describes a Package being manipulated.
-    /// See <c>http://docs.myget.org/docs/reference/webhooks</c> for details.
+    /// See <c>https://docs.myget.org/docs/reference/webhooks</c> for details.
     /// </summary>
     public class Package
     {

--- a/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Payloads/PackageAddedPayload.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Payloads/PackageAddedPayload.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNet.WebHooks.Payloads
 {
     /// <summary>
     /// Payload sent when a package is added.
-    /// See <c>http://docs.myget.org/docs/reference/webhooks</c> for details.
+    /// See <c>https://docs.myget.org/docs/reference/webhooks</c> for details.
     /// </summary>
     public class PackageAddedPayload
     {

--- a/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Payloads/PackageDeletedPayload.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Payloads/PackageDeletedPayload.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNet.WebHooks.Payloads
 {
     /// <summary>
     /// Payload sent when a package is deleted.
-    /// See <c>http://docs.myget.org/docs/reference/webhooks</c> for details.
+    /// See <c>https://docs.myget.org/docs/reference/webhooks</c> for details.
     /// </summary>
     public class PackageDeletedPayload
     {

--- a/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Payloads/PackageListedPayload.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Payloads/PackageListedPayload.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNet.WebHooks.Payloads
 {
     /// <summary>
     /// Payload sent when a package is listed/unlisted.
-    /// See <c>http://docs.myget.org/docs/reference/webhooks</c> for details.
+    /// See <c>https://docs.myget.org/docs/reference/webhooks</c> for details.
     /// </summary>
     public class PackageListedPayload
     {

--- a/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Payloads/PackageMetadata.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Payloads/PackageMetadata.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNet.WebHooks.Payloads
 {
     /// <summary>
     /// Package metadata.
-    /// See <c>http://docs.myget.org/docs/reference/webhooks</c> for details.
+    /// See <c>https://docs.myget.org/docs/reference/webhooks</c> for details.
     /// </summary>
     public class PackageMetadata
     {

--- a/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Payloads/PackagePinnedPayload.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Payloads/PackagePinnedPayload.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNet.WebHooks.Payloads
 {
     /// <summary>
     /// Payload sent when a package is pinned/unpinned.
-    /// See <c>http://docs.myget.org/docs/reference/webhooks</c> for details.
+    /// See <c>https://docs.myget.org/docs/reference/webhooks</c> for details.
     /// </summary>
     public class PackagePinnedPayload
     {

--- a/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Payloads/PackagePushedPayload.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/Payloads/PackagePushedPayload.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNet.WebHooks.Payloads
 {
     /// <summary>
     /// Payload sent when a package is pushed to an upstream feed.
-    /// See <c>http://docs.myget.org/docs/reference/webhooks</c> for details.
+    /// See <c>https://docs.myget.org/docs/reference/webhooks</c> for details.
     /// </summary>
     public class PackagePushedPayload
     {

--- a/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/WebHooks/MyGetWebHookReceiver.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.MyGet/WebHooks/MyGetWebHookReceiver.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNet.WebHooks
     /// For security reasons the WebHook URI must be an <c>https</c> URI and contain a 'code' query parameter with the
     /// same value as configured in the '<c>MS_WebHookReceiverSecret_MyGet</c>' application setting.
     /// The 'code' parameter must be between 32 and 128 characters long.
-    /// For details about MyGet WebHooks, see <c>http://docs.myget.org/docs/reference/webhooks</c>.
+    /// For details about MyGet WebHooks, see <c>https://docs.myget.org/docs/reference/webhooks</c>.
     /// </summary>
     public class MyGetWebHookReceiver : WebHookReceiver
     {

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Paypal/Microsoft.AspNet.WebHooks.Receivers.Paypal.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Paypal/Microsoft.AspNet.WebHooks.Receivers.Paypal.nuspec
@@ -6,12 +6,14 @@
     <title>Microsoft ASP.NET WebHooks Receiver for Paypal</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
-      This package provides support for receiving WebHooks from Paypal using the Paypal .NET SDK, see "https://www.nuget.org/packages/PayPal". For information about Paypal WebHooks, see "https://developer.paypal.com/webapps/developer/docs/integration/direct/rest-webhooks-overview/".
+      This package provides support for receiving WebHooks from Paypal using the Paypal .NET SDK, see
+      https://www.nuget.org/packages/PayPal. For information about Paypal WebHooks, see
+      https://developer.paypal.com/webapps/developer/docs/integration/direct/rest-webhooks-overview/.
     </description>
     <releaseNotes></releaseNotes>
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Pusher/Microsoft.AspNet.WebHooks.Receivers.Pusher.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Pusher/Microsoft.AspNet.WebHooks.Receivers.Pusher.nuspec
@@ -6,12 +6,14 @@
     <title>Microsoft ASP.NET WebHooks Receiver for Pusher</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
-      This package provides support for receiving WebHooks from Pusher. For information about Pusher WebHooks, see "https://pusher.com/docs/webhooks".</description>
+      This package provides support for receiving WebHooks from Pusher. For information about Pusher WebHooks, see
+      https://pusher.com/docs/webhooks.
+    </description>
     <releaseNotes></releaseNotes>
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
     <tags>Microsoft AspNet WebApi AspNetWebApi WebHooks Pusher</tags>

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Salesforce/Extensions/HttpConfigurationExtensions.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Salesforce/Extensions/HttpConfigurationExtensions.cs
@@ -17,7 +17,7 @@ namespace System.Web.Http
         /// A sample WebHook URI is of the form '<c>https://&lt;host&gt;/api/webhooks/incoming/sfsoap/{id}</c>'.
         /// For security reasons, the WebHook URI must be an <c>https</c> URI and the '<c>MS_WebHookReceiverSecret_SalesforceSoap</c>' 
         /// application setting must be configured to the Salesforce Organization IDs. Organizational IDs can be found at 
-        /// <c>http://www.salesforce.com</c> under <c>Setup | Company Profile | Company Information</c>.
+        /// <c>https://www.salesforce.com</c> under <c>Setup | Company Profile | Company Information</c>.
         /// For details about Salesforce Outbound Messages, see <c>https://go.microsoft.com/fwlink/?linkid=838587</c>. 
         /// </summary>
         /// <param name="config">The current <see cref="HttpConfiguration"/>config.</param>

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Salesforce/Microsoft.AspNet.WebHooks.Receivers.SalesForce.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Salesforce/Microsoft.AspNet.WebHooks.Receivers.SalesForce.nuspec
@@ -6,12 +6,13 @@
     <title>Microsoft ASP.NET WebHooks Receiver for Salesforce</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
-      This package provides support for receiving Salesforce SOAP-based Outbound Messages as a WebHook. For information about Salesforce WebHooks, see "https://go.microsoft.com/fwlink/?linkid=838587".
+      This package provides support for receiving Salesforce SOAP-based Outbound Messages as a WebHook. For information
+      about Salesforce WebHooks, see https://go.microsoft.com/fwlink/?linkid=838587.
     </description>
     <releaseNotes></releaseNotes>
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Salesforce/WebHooks/SalesforceSoapWebHookReceiver.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Salesforce/WebHooks/SalesforceSoapWebHookReceiver.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNet.WebHooks
     /// A sample WebHook URI is of the form '<c>https://&lt;host&gt;/api/webhooks/incoming/sfsoap/{id}</c>'.
     /// For security reasons, the WebHook URI must be an <c>https</c> URI and the '<c>MS_WebHookReceiverSecret_SalesforceSoap</c>'
     /// application setting must be configured to the Salesforce Organization IDs. The Organizational IDs can be found at
-    /// <c>http://www.salesforce.com</c> under <c>Setup | Company Profile | Company Information</c>.
+    /// <c>https://www.salesforce.com</c> under <c>Setup | Company Profile | Company Information</c>.
     /// For details about Salesforce Outbound Messages, see <c>https://go.microsoft.com/fwlink/?linkid=838587</c>.
     /// </summary>
     public class SalesforceSoapWebHookReceiver : WebHookReceiver

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Slack/Microsoft.AspNet.WebHooks.Receivers.Slack.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Slack/Microsoft.AspNet.WebHooks.Receivers.Slack.nuspec
@@ -6,12 +6,13 @@
     <title>Microsoft ASP.NET WebHooks Receiver for Slack</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
-      This package provides support for receiving WebHooks from Slack. For information about Slack WebHooks, see "https://api.slack.com/outgoing-webhooks".
+      This package provides support for receiving WebHooks from Slack. For information about Slack WebHooks, see
+      https://api.slack.com/custom-integrations/outgoing-webhooks.
     </description>
     <releaseNotes></releaseNotes>
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Stripe/Microsoft.AspNet.WebHooks.Receivers.Stripe.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Stripe/Microsoft.AspNet.WebHooks.Receivers.Stripe.nuspec
@@ -6,12 +6,13 @@
     <title>Microsoft ASP.NET WebHooks Receiver for Stripe</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
-      This package provides support for receiving WebHooks from Stripe. For information about Stripe WebHooks, see "https://stripe.com/docs/webhooks".
+      This package provides support for receiving WebHooks from Stripe. For information about Stripe WebHooks, see
+      https://stripe.com/docs/webhooks.
     </description>
     <releaseNotes></releaseNotes>
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Trello/Microsoft.AspNet.WebHooks.Receivers.Trello.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Trello/Microsoft.AspNet.WebHooks.Receivers.Trello.nuspec
@@ -6,12 +6,13 @@
     <title>Microsoft ASP.NET WebHooks Receiver for Trello</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
-      This package provides support for receiving WebHooks from Trello. For information about Trello WebHooks, see "https://trello.com/docs/gettingstarted/webhooks.html".
+      This package provides support for receiving WebHooks from Trello. For information about Trello WebHooks, see
+      https://developers.trello.com/page/webhooks.
     </description>
     <releaseNotes></releaseNotes>
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>

--- a/src/Microsoft.AspNet.WebHooks.Receivers.VSTS/Microsoft.AspNet.WebHooks.Receivers.VSTS.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.VSTS/Microsoft.AspNet.WebHooks.Receivers.VSTS.nuspec
@@ -6,12 +6,14 @@
     <title>Microsoft ASP.NET WebHooks Receiver for Visual Studio Team Services</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
-      This package provides support for receiving WebHooks from Visual Studio Team Services. For information about Visual Studio Team Services WebHooks, see "https://www.visualstudio.com/en-us/get-started/integrate/service-hooks/webhooks-and-vso-vs".
+      This package provides support for receiving WebHooks from Visual Studio Team Services. For information about
+      Visual Studio Team Services WebHooks, see
+      https://docs.microsoft.com/en-us/vsts/service-hooks/services/webhooks.
     </description>
     <releaseNotes></releaseNotes>
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>

--- a/src/Microsoft.AspNet.WebHooks.Receivers.WordPress/Microsoft.AspNet.WebHooks.Receivers.WordPress.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.WordPress/Microsoft.AspNet.WebHooks.Receivers.WordPress.nuspec
@@ -6,12 +6,13 @@
     <title>Microsoft ASP.NET WebHooks Receiver for WordPress</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
-      This package provides support for receiving WebHooks from WordPress. For information about WordPress WebHooks, see "https://en.support.wordpress.com/webhooks/".
+      This package provides support for receiving WebHooks from WordPress. For information about WordPress WebHooks,
+      see https://en.support.wordpress.com/webhooks/.
     </description>
     <releaseNotes></releaseNotes>
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>

--- a/src/Microsoft.AspNet.WebHooks.Receivers.Zendesk/Microsoft.AspNet.WebHooks.Receivers.Zendesk.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Receivers.Zendesk/Microsoft.AspNet.WebHooks.Receivers.Zendesk.nuspec
@@ -6,11 +6,14 @@
     <title>Microsoft ASP.NET WebHooks Receiver for Zendesk</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <description>This package provides support for receiving WebHooks from Zendesk. For information about Zendesk WebHooks, see "https://developer.zendesk.com/embeddables/docs/ios/push_notifications_webhook".</description>
+    <description>
+      This package provides support for receiving WebHooks from Zendesk. For information about Zendesk
+      WebHooks, see https://developer.zendesk.com/embeddables/docs/ios/push_notifications_webhook.
+    </description>
     <releaseNotes></releaseNotes>
     <copyright>&#169; Microsoft Corporation. All rights reserved.</copyright>
     <tags>Microsoft AspNet WebApi AspNetWebApi WebHooks Zendesk</tags>

--- a/src/Microsoft.AspNet.WebHooks.Receivers/Microsoft.AspNet.WebHooks.Receivers.nuspec
+++ b/src/Microsoft.AspNet.WebHooks.Receivers/Microsoft.AspNet.WebHooks.Receivers.nuspec
@@ -6,9 +6,9 @@
     <title>Microsoft ASP.NET WebHooks Receivers</title>
     <authors>Microsoft</authors>
     <owners>Microsoft, aspnet</owners>
-    <licenseUrl>http://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</licenseUrl>
-    <projectUrl>http://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
-    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <licenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_enu.htm</licenseUrl>
+    <projectUrl>https://go.microsoft.com/fwlink/?LinkId=690277</projectUrl>
+    <iconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
       This package provides a uniform model for receiving WebHooks from an open-ended set of WebHook generators such as Dropbox, GitHub, Slack, and many more.

--- a/src/Microsoft.AspNet.WebHooks.Receivers/WebHooks/WebHookAssemblyResolver.cs
+++ b/src/Microsoft.AspNet.WebHooks.Receivers/WebHooks/WebHookAssemblyResolver.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNet.WebHooks
     /// Provides a custom <see cref="IAssembliesResolver"/> implementation that ensures that the WebHooks receiver 
     /// assemblies are loaded. This is useful when running ASP.NET Web API using the OWIN Self Host as there 
     /// assemblies have to be loaded explicitly. For more information on running Web API in a self host, please see 
-    /// '<c>http://www.asp.net/web-api/overview/hosting-aspnet-web-api/use-owin-to-self-host-web-api</c>'.
+    /// '<c>https://www.asp.net/web-api/overview/hosting-aspnet-web-api/use-owin-to-self-host-web-api</c>'.
     /// </summary>
     public class WebHookAssemblyResolver : DefaultAssembliesResolver
     {


### PR DESCRIPTION
- remove double quotes around URLs in `<description>` (#195)
  - will send another PR (after next build) if a URL then a period looks odd on MyGet
- use HTTPS for all URLs in these files (none were HTTP-only)
  - do the same thing for C# and a few HTML files where target site supports HTTPS
- replace links to sender documentation where they've gotten stale