### PR TITLE
Clean up logging

### DIFF
--- a/samples/BitbucketCoreReceiver/Controllers/BitbucketController.cs
+++ b/samples/BitbucketCoreReceiver/Controllers/BitbucketController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebHooks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
@@ -24,10 +24,8 @@ namespace BitbucketCoreReceiver.Controllers
 
             _logger.LogInformation(
                 0,
-                "{ControllerName} received '{EventName}' for '{Id}' and '{WebHookId}'.",
-                nameof(BitbucketController),
+                $"{nameof(BitbucketController)} / 'It' received '{{EventName}}' and '{{WebHookId}}'.",
                 @event,
-                "It",
                 webHookId);
 
             return Ok();
@@ -70,10 +68,9 @@ namespace BitbucketCoreReceiver.Controllers
 
             _logger.LogInformation(
                 1,
-                "{ControllerName} received '{EventName}' for '{Id}' and '{WebHookId}'.",
-                nameof(BitbucketController),
-                @event,
+                $"{nameof(BitbucketController)} / '{{Id}}' received '{{EventName}}' and '{{WebHookId}}'.",
                 id,
+                @event,
                 webHookId);
 
             return Ok();

--- a/samples/BitbucketStronglyTypedCoreReceiver/Controllers/BitbucketController.cs
+++ b/samples/BitbucketStronglyTypedCoreReceiver/Controllers/BitbucketController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebHooks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
@@ -24,10 +24,8 @@ namespace BitbucketStronglyTypedCoreReceiver.Controllers
 
             _logger.LogInformation(
                 0,
-                "{ControllerName} received '{EventName}' for '{Id}' and '{WebHookId}'.",
-                nameof(BitbucketController),
+                $"{nameof(BitbucketController)} / 'It' received '{{EventName}}' and '{{WebHookId}}'.",
                 @event,
-                "It",
                 webHookId);
 
             return Ok();
@@ -70,10 +68,9 @@ namespace BitbucketStronglyTypedCoreReceiver.Controllers
 
             _logger.LogInformation(
                 1,
-                "{ControllerName} received '{EventName}' for '{Id}' and '{WebHookId}'.",
-                nameof(BitbucketController),
-                @event,
+                $"{nameof(BitbucketController)} / '{{Id}}' received '{{EventName}}' and '{{WebHookId}}'.",
                 id,
+                @event,
                 webHookId);
 
             return Ok();

--- a/samples/DynamicsCRMCoreReceiver/Controllers/DynamicsCRMController.cs
+++ b/samples/DynamicsCRMCoreReceiver/Controllers/DynamicsCRMController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebHooks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
@@ -24,10 +24,8 @@ namespace DynamicsCRMCoreReceiver.Controllers
 
             _logger.LogInformation(
                 0,
-                "{ControllerName} received '{MessageName}' for '{Id}'.",
-                nameof(DynamicsCRMController),
-                @event,
-                "It");
+                $"{nameof(DynamicsCRMController)} / 'It' received '{{MessageName}}'.",
+                @event);
 
             return Ok();
         }
@@ -42,10 +40,9 @@ namespace DynamicsCRMCoreReceiver.Controllers
 
             _logger.LogInformation(
                 1,
-                "{ControllerName} received '{MessageName}' for '{Id}'.",
-                nameof(DynamicsCRMController),
-                @event,
-                id);
+                $"{nameof(DynamicsCRMController)} / '{{Id}}' received '{{MessageName}}'.",
+                id,
+                @event);
 
             return Ok();
         }

--- a/samples/PusherCoreReceiver/Controllers/PusherController.cs
+++ b/samples/PusherCoreReceiver/Controllers/PusherController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebHooks;
 using Microsoft.Extensions.Logging;
@@ -28,8 +28,8 @@ namespace PusherCoreReceiver.Controllers
             var createdAt = DateTimeOffset.FromUnixTimeMilliseconds(createdAtUnix);
             _logger.LogInformation(
                 0,
-                "{ControllerName} received {Count} notifications and {EventCount} events created at '{CreatedAt}'.",
-                nameof(PusherController),
+                $"{nameof(PusherController)} / 'It' received {{Count}} notifications and {{EventCount}} events " +
+                "created at '{CreatedAt}'.",
                 data.Events.Count,
                 eventNames.Length,
                 createdAt.ToString("o"));
@@ -71,12 +71,12 @@ namespace PusherCoreReceiver.Controllers
                 }
                 else
                 {
-                    _logger.LogError(
+                    _logger.LogWarning(
                         4,
-                        "Event {EventNumber} has {Count} properties but does not contain a {PropertyName} property.",
+                        "Event {EventNumber} has {Count} properties but does not contain a " +
+                        $"{PusherConstants.EventNamePropertyName} property.",
                         index,
-                        @event.Count,
-                        PusherConstants.EventNamePropertyName);
+                        @event.Count);
                 }
 
                 index++;
@@ -99,9 +99,8 @@ namespace PusherCoreReceiver.Controllers
             var events = data.Value<JArray>(PusherConstants.EventRequestPropertyContainerName);
             _logger.LogInformation(
                 5,
-                "{ControllerName} / '{Id}' received {Count} notifications and {EventCount} events created at " +
-                "'{CreatedAt}'.",
-                nameof(PusherController),
+                $"{nameof(PusherController)} / '{{Id}}' received {{Count}} notifications and {{EventCount}} events " +
+                "created at '{CreatedAt}'.",
                 id,
                 events.Count,
                 eventNames.Length,
@@ -147,12 +146,12 @@ namespace PusherCoreReceiver.Controllers
                 }
                 else
                 {
-                    _logger.LogError(
+                    _logger.LogWarning(
                         9,
-                        "Event {EventNumber} has {Count} properties but does not contain a {PropertyName} property.",
+                        "Event {EventNumber} has {Count} properties but does not contain a " +
+                        $"{PusherConstants.EventNamePropertyName} property.",
                         index,
-                        @event.Count,
-                        PusherConstants.EventNamePropertyName);
+                        @event.Count);
                 }
 
                 index++;

--- a/samples/SalesforceCoreReceiver/Controllers/SalesforceController.cs
+++ b/samples/SalesforceCoreReceiver/Controllers/SalesforceController.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.Mvc;
@@ -39,9 +39,8 @@ namespace SalesforceCoreReceiver.Controllers
 
             _logger.LogInformation(
                 0,
-                "{ControllerName} / '{ReceiverId}' received {Count} notifications with ActionId '{ActionId}' (event " +
-                "'{EventName}').",
-                nameof(SalesforceController),
+                $"{nameof(SalesforceController)} / '{{ReceiverId}}' received {{Count}} notifications with ActionId " +
+                "'{ActionId}' (event '{EventName}').",
                 id,
                 data.Notifications.Count(),
                 data.ActionId,

--- a/samples/SlackCoreReceiver/Controllers/SlackController.cs
+++ b/samples/SlackCoreReceiver/Controllers/SlackController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebHooks;
 using Microsoft.Extensions.Logging;
@@ -24,9 +24,7 @@ namespace SlackCoreReceiver.Controllers
 
             _logger.LogInformation(
                 0,
-                "{ControllerName} / '{ReceiverId}' received {Count} properties with event '{EventName}').",
-                nameof(SlackController),
-                "command",
+                $"{nameof(SlackController)} / 'command' received {{Count}} properties with event '{{EventName}}'.",
                 data.Count,
                 @event);
 
@@ -88,9 +86,7 @@ namespace SlackCoreReceiver.Controllers
 
             _logger.LogInformation(
                 3,
-                "{ControllerName} / '{ReceiverId}' received {Count} properties with event '{EventName}').",
-                nameof(SlackController),
-                "trigger",
+                $"{nameof(SlackController)} / 'trigger' received {{Count}} properties with event '{{EventName}}'.",
                 data.Count,
                 @event);
 
@@ -134,8 +130,8 @@ namespace SlackCoreReceiver.Controllers
 
             _logger.LogInformation(
                 6,
-                "{ControllerName} / '{ReceiverId}' received {Count} properties with event '{EventName}').",
-                nameof(SlackController),
+                $"{nameof(SlackController)} / '{{ReceiverId}}' received {{Count}} properties with event " +
+                "'{EventName}'.",
                 id,
                 data.Count,
                 @event);

--- a/samples/StripeCoreReceiver/Controllers/StripeController.cs
+++ b/samples/StripeCoreReceiver/Controllers/StripeController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebHooks;
 using Microsoft.Extensions.Logging;
@@ -36,8 +36,8 @@ namespace StripeCoreReceiver.Controllers
 
             _logger.LogInformation(
                 0,
-                "{ControllerName} / '{ReceiverId}' received a '{EventType}' notification (event '{EventName}').",
-                nameof(StripeController),
+                $"{nameof(StripeController)} / '{{ReceiverId}}' received a '{{EventType}}' notification (event " +
+                "'{EventName}').",
                 id,
                 data.EventType,
                 @event);

--- a/samples/TrelloCoreReceiver/Controllers/TrelloController.cs
+++ b/samples/TrelloCoreReceiver/Controllers/TrelloController.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebHooks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
@@ -24,10 +24,8 @@ namespace TrelloCoreReceiver.Controllers
 
             _logger.LogInformation(
                 0,
-                "{ControllerName} received '{MessageName}' for '{Id}'.",
-                nameof(TrelloController),
-                @event,
-                "It");
+                $"{nameof(TrelloController)} / 'It' received '{{MessageName}}'.",
+                @event);
 
             return Ok();
         }
@@ -42,10 +40,9 @@ namespace TrelloCoreReceiver.Controllers
 
             _logger.LogInformation(
                 1,
-                "{ControllerName} received '{MessageName}' for '{Id}'.",
-                nameof(TrelloController),
-                @event,
-                id);
+                $"{nameof(TrelloController)} / '{{Id}}' received '{{MessageName}}'.",
+                id,
+                @event);
 
             return Ok();
         }

--- a/samples/WordPressCoreReceiver/Controllers/WordPressController.cs
+++ b/samples/WordPressCoreReceiver/Controllers/WordPressController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebHooks;
@@ -25,9 +25,7 @@ namespace WordPressCoreReceiver.Controllers
 
             _logger.LogInformation(
                0,
-               "{ControllerName} / '{ReceiverId}' received {Count} properties with event '{EventName}').",
-               nameof(WordPressController),
-               "It",
+               $"{nameof(WordPressController)} / 'It' received {{Count}} properties with event '{{EventName}}'.",
                data.Count,
                @event);
             foreach (var keyValuePair in data)
@@ -60,8 +58,8 @@ namespace WordPressCoreReceiver.Controllers
 
             _logger.LogInformation(
                2,
-               "{ControllerName} / '{ReceiverId}' received {Count} properties with event '{EventName}').",
-               nameof(WordPressController),
+               $"{nameof(WordPressController)} / '{{ReceiverId}}' received {{Count}} properties with event " +
+               "'{EventName}'.",
                id,
                data.Count,
                @event);

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Dropbox/Filters/DropboxVerifySignatureFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Dropbox/Filters/DropboxVerifySignatureFilter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.GitHub/Filters/GitHubVerifySignatureFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.GitHub/Filters/GitHubVerifySignatureFilter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -95,12 +95,10 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
                         GitHubConstants.SignatureHeaderKey,
                         StringComparison.OrdinalIgnoreCase))
                 {
-                    Logger.LogError(
-                        1,
-                        "Invalid '{HeaderName}' header value. Expecting a value of '{Key}={Value}'.",
-                        GitHubConstants.SignatureHeaderName,
-                        GitHubConstants.SignatureHeaderKey,
-                        "<value>");
+                    Logger.LogWarning(
+                        0,
+                        $"Invalid '{GitHubConstants.SignatureHeaderName}' header value. Expecting a value of " +
+                        $"'{GitHubConstants.SignatureHeaderKey}=<value>'.");
 
                     var message = string.Format(
                         CultureInfo.CurrentCulture,

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Pusher/Filters/PusherVerifySignatureFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Pusher/Filters/PusherVerifySignatureFilter.cs
@@ -110,12 +110,11 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
                     secretKey.Length < PusherConstants.SecretKeyMinLength ||
                     secretKey.Length > PusherConstants.SecretKeyMaxLength)
                 {
-                    Logger.LogError(
+                    Logger.LogWarning(
                         0,
-                        "The '{HeaderName}' header value of '{HeaderValue}' is not recognized as a valid " +
-                        "application key. Ensure the correct application key / secret key pairs have " +
-                        "been configured.",
-                        PusherConstants.SignatureKeyHeaderName,
+                        $"The '{PusherConstants.SignatureKeyHeaderName}' header value of '{{HeaderValue}}' is not " +
+                        "recognized as a valid application key. Ensure the correct application key / secret key " +
+                        "pairs have been configured.",
                         applicationKey);
 
                     var message = string.Format(

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/Filters/SalesforceVerifyOrganizationIdFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/Filters/SalesforceVerifyOrganizationIdFilter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -121,10 +121,10 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
             var organizationIds = ObjectPathUtilities.GetStringValues(data, SalesforceConstants.OrganizationIdPath);
             if (StringValues.IsNullOrEmpty(organizationIds))
             {
-                Logger.LogError(
+                Logger.LogWarning(
                     0,
-                    "The HTTP request body did not contain a required '{XPath}' element.",
-                    SalesforceConstants.OrganizationIdPath);
+                    $"The HTTP request body did not contain a required '{SalesforceConstants.OrganizationIdPath}' " +
+                    "element.");
 
                 var message = string.Format(
                     CultureInfo.CurrentCulture,
@@ -145,10 +145,10 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
             var secretKey = GetShortOrganizationId(secret);
             if (!SecretEqual(organizationId, secretKey))
             {
-                Logger.LogError(
+                Logger.LogWarning(
                     1,
-                    "The '{XPath}' value provided in the HTTP request body did not match the expected value.",
-                    SalesforceConstants.OrganizationIdPath);
+                    $"The '{SalesforceConstants.OrganizationIdPath}' value provided in the HTTP request body did " +
+                    "not match the expected value.");
 
                 var message = string.Format(
                     CultureInfo.CurrentCulture,
@@ -163,10 +163,10 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
             var eventNames = ObjectPathUtilities.GetStringValues(data, SalesforceConstants.EventNamePath);
             if (StringValues.IsNullOrEmpty(eventNames))
             {
-                Logger.LogError(
+                Logger.LogWarning(
                     2,
-                    "The HTTP request body did not contain a required '{XPath}' element.",
-                    SalesforceConstants.EventNamePath);
+                    $"The HTTP request body did not contain a required '{SalesforceConstants.EventNamePath}' " +
+                    "element.");
 
                 var message = string.Format(
                     CultureInfo.CurrentCulture,

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/Internal/SalesforceResultCreator.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/Internal/SalesforceResultCreator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebHooks.Properties;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.WebHooks.Internal
 {
@@ -17,17 +16,6 @@ namespace Microsoft.AspNetCore.WebHooks.Internal
     /// </summary>
     public class SalesforceResultCreator : ISalesforceResultCreator
     {
-        private readonly ILogger _logger;
-
-        /// <summary>
-        /// Instantiates a new <see cref="SalesforceResultCreator"/> instance.
-        /// </summary>
-        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
-        public SalesforceResultCreator(ILoggerFactory loggerFactory)
-        {
-            _logger = loggerFactory.CreateLogger<SalesforceResultCreator>();
-        }
-
         /// <inheritdoc />
         public async Task<ContentResult> GetFailedResultAsync(string message)
         {
@@ -82,12 +70,6 @@ namespace Microsoft.AspNetCore.WebHooks.Internal
             if (content == null)
             {
                 var assemblyName = assembly.GetName().Name;
-                _logger.LogCritical(
-                    3,
-                    "No '{0}' embedded resource found in the '{1}' assembly.",
-                    resourceName,
-                    assemblyName);
-
                 var message = string.Format(
                     CultureInfo.CurrentCulture,
                     Resources.ResultCreator_MissingResource,

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/Filters/SlackVerifyTokenFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/Filters/SlackVerifyTokenFilter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -106,10 +106,10 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
             string token = data[SlackConstants.TokenRequestFieldName];
             if (string.IsNullOrEmpty(token))
             {
-                Logger.LogError(
+                Logger.LogWarning(
                     0,
-                    "The HTTP request body did not contain a required '{PropertyName}' property.",
-                    SlackConstants.TokenRequestFieldName);
+                    $"The HTTP request body did not contain a required '{SlackConstants.TokenRequestFieldName}' " +
+                    "property.");
 
                 var message = string.Format(
                     CultureInfo.CurrentCulture,
@@ -128,10 +128,10 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
 
             if (!SecretEqual(token, secretKey))
             {
-                Logger.LogError(
+                Logger.LogWarning(
                     1,
-                    "The '{PropertyName}' value provided in the HTTP request body did not match the expected value.",
-                    SlackConstants.TokenRequestFieldName);
+                    $"The '{SlackConstants.TokenRequestFieldName}' value provided in the HTTP request body did not " +
+                    "match the expected value.");
 
                 var message = string.Format(
                     CultureInfo.CurrentCulture,
@@ -163,13 +163,11 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
 
             if (string.IsNullOrEmpty(eventName))
             {
-                Logger.LogError(
+                Logger.LogWarning(
                     2,
-                    "The HTTP request body did not contain a required '{PropertyName1}', '{PropertyName2}', or " +
-                    "'{PropertyName3}' property.",
-                    SlackConstants.TriggerRequestFieldName,
-                    SlackConstants.CommandRequestFieldName,
-                    SlackConstants.TextRequestFieldName);
+                    $"The HTTP request body did not contain a required '{SlackConstants.TriggerRequestFieldName}', " +
+                    $"'{SlackConstants.CommandRequestFieldName}', or '{SlackConstants.TextRequestFieldName}' " +
+                    "property.");
 
                 var message = string.Format(
                     CultureInfo.CurrentCulture,

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Stripe/Filters/StripeTestEventRequestFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Stripe/Filters/StripeTestEventRequestFilter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
                 var passThroughString = _configuration[StripeConstants.PassThroughTestEventsConfigurationKey];
                 if (bool.TryParse(passThroughString, out var passThrough) && passThrough)
                 {
-                    _logger.LogInformation(0, "Received a Stripe Test Event.");
+                    _logger.LogDebug(0, "Received a Stripe Test Event.");
                 }
                 else
                 {

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Stripe/Filters/StripeVerifyNotificationIdFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Stripe/Filters/StripeVerifyNotificationIdFilter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -100,10 +100,10 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
             var notificationId = data.Value<string>(StripeConstants.NotificationIdPropertyName);
             if (string.IsNullOrEmpty(notificationId))
             {
-                _logger.LogError(
+                _logger.LogWarning(
                     0,
-                    "The HTTP request body did not contain a required '{PropertyName}' property.",
-                    StripeConstants.NotificationIdPropertyName);
+                    "The HTTP request body did not contain a required " +
+                    $"'{StripeConstants.NotificationIdPropertyName}' property.");
 
                 var message = string.Format(
                     CultureInfo.CurrentCulture,
@@ -118,10 +118,10 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
             var eventName = data.Value<string>(StripeConstants.EventPropertyName);
             if (string.IsNullOrEmpty(eventName))
             {
-                _logger.LogError(
+                _logger.LogWarning(
                     1,
-                    "The HTTP request body did not contain a required '{PropertyName}' property.",
-                    StripeConstants.EventPropertyName);
+                    $"The HTTP request body did not contain a required '{StripeConstants.EventPropertyName}' " +
+                    "property.");
 
                 var message = string.Format(
                     CultureInfo.CurrentCulture,

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Stripe/Filters/StripeVerifySignatureFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Stripe/Filters/StripeVerifySignatureFilter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -197,10 +197,10 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
                 if (keyValuePair.Count != 2)
                 {
                     // Header is not formatted correctly.
-                    Logger.LogError(
-                        2,
-                        "The '{HeaderName}' header value is invalid. '{InvalidPair}' should be a 'key=value' pair.",
-                        StripeConstants.SignatureHeaderName,
+                    Logger.LogWarning(
+                        0,
+                        $"The '{StripeConstants.SignatureHeaderName}' header value is invalid. '{{InvalidPair}}' " +
+                        "should be a 'key=value' pair.",
                         pair);
 
                     var message = string.Format(
@@ -228,20 +228,18 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
 
             if (!hasSignature)
             {
-                Logger.LogError(
-                    3,
-                    "The '{HeaderName}' header value is invalid. Does not contain a timestamp ('{Key}') value.",
-                    StripeConstants.SignatureHeaderName,
-                    StripeConstants.SignatureKey);
+                Logger.LogWarning(
+                    1,
+                    $"The '{StripeConstants.SignatureHeaderName}' header value is invalid. Does not contain a " +
+                    $"timestamp ('{StripeConstants.SignatureKey}') value.");
             }
 
             if (!hasTimestamp)
             {
-                Logger.LogError(
-                    4,
-                    "The '{HeaderName}' header value is invalid. Does not contain a signature ('{Key}') value.",
-                    StripeConstants.SignatureHeaderName,
-                    StripeConstants.TimestampKey);
+                Logger.LogWarning(
+                    2,
+                    $"The '{StripeConstants.SignatureHeaderName}' header value is invalid. Does not contain a " +
+                    $"signature ('{StripeConstants.TimestampKey}') value.");
             }
 
             if (!hasSignature || !hasTimestamp)

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Stripe/ModelBinding/UnixTimeConverter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Stripe/ModelBinding/UnixTimeConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.WebHooks.ModelBinding
                 var message = string.Format(
                     CultureInfo.CurrentCulture,
                     Resources.DateTime_NullError,
-                    nameof(DateTime));
+                    typeof(DateTime));
                 throw new InvalidOperationException(message);
             }
 
@@ -87,7 +87,7 @@ namespace Microsoft.AspNetCore.WebHooks.ModelBinding
                         CultureInfo.CurrentCulture,
                         Resources.DateTime_BadFormat,
                         reader.Value,
-                        nameof(DateTime));
+                        typeof(DateTime));
                     throw new InvalidOperationException(message);
                 }
             }
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.WebHooks.ModelBinding
                     CultureInfo.CurrentCulture,
                     Resources.DateTime_BadFormat,
                     reader.Value,
-                    nameof(DateTime));
+                    typeof(DateTime));
                 throw new InvalidOperationException(message);
             }
 

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookPingRequestFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookPingRequestFilter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookVerifyCodeFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookVerifyCodeFilter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -121,12 +121,12 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
             var code = request.Query[WebHookConstants.CodeQueryParameterName];
             if (StringValues.IsNullOrEmpty(code))
             {
-                Logger.LogError(
+                Logger.LogWarning(
                     400,
-                    "A '{ReceiverName}' WebHook verification request must contain a '{ParameterName}' query " +
+                    "A '{ReceiverName}' WebHook verification request must contain a " +
+                    $"'{WebHookConstants.CodeQueryParameterName}' query " +
                     "parameter.",
-                    receiverName,
-                    WebHookConstants.CodeQueryParameterName);
+                    receiverName);
 
                 var message = string.Format(
                     CultureInfo.CurrentCulture,
@@ -150,11 +150,10 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
 
             if (!SecretEqual(code, secretKey))
             {
-                Logger.LogError(
+                Logger.LogWarning(
                     401,
-                    "The '{ParameterName}' query parameter provided in the HTTP request did not match the " +
-                    "expected value.",
-                    WebHookConstants.CodeQueryParameterName);
+                    $"The '{WebHookConstants.CodeQueryParameterName}' query parameter provided in the HTTP request " +
+                    "did not match the expected value.");
 
                 var message = string.Format(
                     CultureInfo.CurrentCulture,

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookVerifyMethodFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookVerifyMethodFilter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -93,7 +93,7 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
 
         private IActionResult CreateBadMethodResult(string methodName, string receiverName)
         {
-            _logger.LogError(
+            _logger.LogWarning(
                 0,
                 "The HTTP '{RequestMethod}' method is not supported by the '{ReceiverName}' WebHook receiver.",
                 methodName,
@@ -104,7 +104,6 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
                 Resources.VerifyMethod_BadMethod,
                 methodName,
                 receiverName);
-
             var badMethod = new BadRequestObjectResult(message)
             {
                 StatusCode = StatusCodes.Status405MethodNotAllowed

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookVerifyRequiredValueFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookVerifyRequiredValueFilter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -127,7 +127,7 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
                             message = string.Format(
                                 CultureInfo.CurrentCulture,
                                 Resources.General_InvalidEnumValue,
-                                nameof(WebHookParameterType),
+                                typeof(WebHookParameterType),
                                 parameter.ParameterType);
                             throw new InvalidOperationException(message);
                     }
@@ -155,8 +155,8 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
                 return true;
             }
 
-            _logger.LogError(
-                500,
+            _logger.LogWarning(
+                0,
                 "A '{ReceiverName}' WebHook request must contain a '{KeyName}' value in the route data.",
                 receiverName,
                 keyName);
@@ -181,8 +181,8 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
                 return true;
             }
 
-            _logger.LogError(
-                501,
+            _logger.LogWarning(
+                1,
                 "A '{ReceiverName}' WebHook request must contain a '{HeaderName}' HTTP header.",
                 receiverName,
                 headerName);
@@ -207,8 +207,8 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
                 return true;
             }
 
-            _logger.LogError(
-                502,
+            _logger.LogWarning(
+                2,
                 "A '{ReceiverName}' WebHook request must contain a '{QueryParameterName}' query parameter.",
                 receiverName,
                 parameterName);

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookVerifySignatureFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookVerifySignatureFilter.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
             }
             catch (FormatException exception)
             {
-                Logger.LogError(
+                Logger.LogWarning(
                     400,
                     exception,
                     "The '{HeaderName}' header value is invalid. The '{ReceiverName}' receiver requires a valid " +
@@ -120,7 +120,7 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
 
                 if (input != content.Length)
                 {
-                    Logger.LogError(
+                    Logger.LogWarning(
                         401,
                         "The '{HeaderName}' header value is invalid. The '{ReceiverName}' receiver requires a valid " +
                         "hex-encoded string.",
@@ -136,7 +136,7 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
             {
                 // FormatException is most likely. ToByte throws an ArgumentException when e.g. content contains a
                 // minus sign ('-').
-                Logger.LogError(
+                Logger.LogWarning(
                     402,
                     exception,
                     "The '{HeaderName}' header value is invalid. The '{ReceiverName}' receiver requires a valid " +
@@ -205,7 +205,7 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
             if (!request.Headers.TryGetValue(headerName, out var headers) || headers.Count != 1)
             {
                 var headersCount = headers.Count;
-                Logger.LogInformation(
+                Logger.LogWarning(
                     403,
                     "Expecting exactly one '{HeaderName}' header field in the WebHook request but found " +
                     "{HeaderCount}. Ensure the request contains exactly one '{HeaderName}' header field.",
@@ -296,7 +296,7 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
             }
             if (secret.Length == 0)
             {
-                throw new ArgumentException(Resources.General_ArgumentCannotBeNullOrEmpty);
+                throw new ArgumentException(Resources.General_ArgumentCannotBeNullOrEmpty, nameof(secret));
             }
 
             await WebHookHttpRequestUtilities.PrepareRequestBody(request);
@@ -419,7 +419,7 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
             }
             if (secret.Length == 0)
             {
-                throw new ArgumentException(Resources.General_ArgumentCannotBeNullOrEmpty);
+                throw new ArgumentException(Resources.General_ArgumentCannotBeNullOrEmpty, nameof(secret));
             }
 
             await WebHookHttpRequestUtilities.PrepareRequestBody(request);
@@ -541,7 +541,7 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
                 throw new ArgumentNullException(nameof(signatureHeaderName));
             }
 
-            Logger.LogError(
+            Logger.LogWarning(
                 404,
                 "The WebHook signature provided by the '{HeaderName}' header field does not match the value " +
                 "expected by the '{ReceiverName}' receiver. WebHook request is invalid.",

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Metadata/WebHookParameter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Metadata/WebHookParameter.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.WebHooks.Properties;
 
 namespace Microsoft.AspNetCore.WebHooks.Metadata
@@ -45,11 +46,11 @@ namespace Microsoft.AspNetCore.WebHooks.Metadata
         {
             if (string.IsNullOrEmpty(name))
             {
-                throw new System.ArgumentException(Resources.General_ArgumentCannotBeNullOrEmpty, nameof(name));
+                throw new ArgumentException(Resources.General_ArgumentCannotBeNullOrEmpty, nameof(name));
             }
             if (string.IsNullOrEmpty(sourceName))
             {
-                throw new System.ArgumentException(Resources.General_ArgumentCannotBeNullOrEmpty, nameof(sourceName));
+                throw new ArgumentException(Resources.General_ArgumentCannotBeNullOrEmpty, nameof(sourceName));
             }
 
             Name = name;

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Properties/Resources.Designer.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNetCore.WebHooks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid WebHook constraint configuration encountered. &apos;{0}&apos; executed though request contained no receiver name and &apos;{1}&apos; should have disallowed the request..
+        ///   Looks up a localized string similar to Invalid WebHook constraint configuration encountered. Request contained no receiver name and &apos;{0}&apos; should have disallowed the request..
         /// </summary>
         internal static string EventConstraints_NoReceiverName {
             get {

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Properties/Resources.resx
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Properties/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="EventConstraints_NoReceiverName" xml:space="preserve">
-    <value>Invalid WebHook constraint configuration encountered. '{0}' executed though request contained no receiver name and '{1}' should have disallowed the request.</value>
+    <value>Invalid WebHook constraint configuration encountered. Request contained no receiver name and '{0}' should have disallowed the request.</value>
   </data>
   <data name="EventMapper_NoBodyProperty" xml:space="preserve">
     <value>A '{0}' WebHook request must contain a match for '{1}' in the HTTP request entity body indicating the type or types of event.</value>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookEventMapperConstraint.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookEventMapperConstraint.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -71,7 +71,6 @@ namespace Microsoft.AspNetCore.WebHooks.Routing
             var message = string.Format(
                 CultureInfo.CurrentCulture,
                 Resources.EventConstraints_NoReceiverName,
-                typeof(WebHookEventMapperConstraint),
                 typeof(WebHookReceiverExistsConstraint));
             throw new InvalidOperationException(message);
         }
@@ -131,8 +130,8 @@ namespace Microsoft.AspNetCore.WebHooks.Routing
             routeData.TryGetWebHookReceiverName(out var receiverName);
             if (eventMetadata.QueryParameterName == null)
             {
-                _logger.LogError(
-                    500,
+                _logger.LogWarning(
+                    0,
                     "A '{ReceiverName}' WebHook request must contain a '{HeaderName}' HTTP header " +
                     "indicating the type of event.",
                     receiverName,
@@ -140,8 +139,8 @@ namespace Microsoft.AspNetCore.WebHooks.Routing
             }
             else if (eventMetadata.HeaderName == null)
             {
-                _logger.LogError(
-                    501,
+                _logger.LogWarning(
+                    1,
                     "A '{ReceiverName}' WebHook request must contain a '{QueryParameterKey}' query " +
                     "parameter indicating the type of event.",
                     receiverName,
@@ -149,8 +148,8 @@ namespace Microsoft.AspNetCore.WebHooks.Routing
             }
             else
             {
-                _logger.LogError(
-                    502,
+                _logger.LogWarning(
+                    2,
                     "A '{ReceiverName}' WebHook request must contain a '{HeaderName}' HTTP header or a " +
                     "'{QueryParameterKey}' query parameter indicating the type of event.",
                     receiverName,

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookMultipleEventNamesConstraint.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookMultipleEventNamesConstraint.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -62,7 +62,6 @@ namespace Microsoft.AspNetCore.WebHooks.Routing
             var message = string.Format(
                 CultureInfo.CurrentCulture,
                 Resources.EventConstraints_NoReceiverName,
-                typeof(WebHookMultipleEventNamesConstraint),
                 typeof(WebHookReceiverExistsConstraint));
             throw new InvalidOperationException(message);
         }

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookReceiverNameConstraint.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookReceiverNameConstraint.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/test/Microsoft.AspNetCore.WebHooks.Receivers.Stripe.Test/ModelBinding/UnixTimeConverterTests.cs
+++ b/test/Microsoft.AspNetCore.WebHooks.Receivers.Stripe.Test/ModelBinding/UnixTimeConverterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.WebHooks.ModelBinding
             var ex = Assert.Throws<InvalidOperationException>(() => JsonConvert.DeserializeObject<TestClass>(input));
 
             // Assert
-            Assert.Equal("Cannot convert null value to type 'DateTime'.", ex.Message);
+            Assert.Equal("Cannot convert null value to type 'System.DateTime'.", ex.Message);
         }
 
         [Theory]


### PR DESCRIPTION
- part of [discussion](https://github.com/aspnet/WebHooks/pull/254#discussion_r171360149) in #254
- don't log immediately before `throw`ing an `Exception`
- reduce log levels
- inline type names and other constants
- start event ids at `0` where possible