### PR TITLE
Register metadata services as exact interfaces they implement, not `IWebHookMetadata`

### DIFF
--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.AzureAlert/Internal/AzureAlertServiceCollectionSetup.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.AzureAlert/Internal/AzureAlertServiceCollectionSetup.cs
@@ -1,10 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.AspNetCore.WebHooks.Metadata;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.AspNetCore.WebHooks.Internal
 {
@@ -24,7 +23,7 @@ namespace Microsoft.AspNetCore.WebHooks.Internal
                 throw new ArgumentNullException(nameof(services));
             }
 
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IWebHookMetadata, AzureAlertMetadata>());
+            WebHookMetadata.Register<AzureAlertMetadata>(services);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.BitBucket/Internal/BitbucketServiceCollectionSetup.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.BitBucket/Internal/BitbucketServiceCollectionSetup.cs
@@ -1,10 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.AspNetCore.WebHooks.Metadata;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.AspNetCore.WebHooks.Internal
 {
@@ -24,7 +23,7 @@ namespace Microsoft.AspNetCore.WebHooks.Internal
                 throw new ArgumentNullException(nameof(services));
             }
 
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IWebHookMetadata, BitbucketMetadata>());
+            WebHookMetadata.Register<BitbucketMetadata>(services);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Dropbox/Internal/DropboxServiceCollectionSetup.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Dropbox/Internal/DropboxServiceCollectionSetup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.WebHooks.Internal
             }
 
             services.TryAddEnumerable(ServiceDescriptor.Transient<IConfigureOptions<MvcOptions>, MvcOptionsSetup>());
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IWebHookMetadata, DropboxMetadata>());
+            WebHookMetadata.Register<DropboxMetadata>(services);
 
             services.TryAddSingleton<DropboxVerifySignatureFilter>();
         }

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.DynamicsCRM/Internal/DynamicsCRMServiceCollectionSetup.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.DynamicsCRM/Internal/DynamicsCRMServiceCollectionSetup.cs
@@ -1,10 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.AspNetCore.WebHooks.Metadata;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.AspNetCore.WebHooks.Internal
 {
@@ -24,7 +23,7 @@ namespace Microsoft.AspNetCore.WebHooks.Internal
                 throw new ArgumentNullException(nameof(services));
             }
 
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IWebHookMetadata, DynamicsCRMMetadata>());
+            WebHookMetadata.Register<DynamicsCRMMetadata>(services);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.GitHub/Internal/GitHubServiceCollectionSetup.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.GitHub/Internal/GitHubServiceCollectionSetup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -28,7 +28,8 @@ namespace Microsoft.AspNetCore.WebHooks.Internal
             }
 
             services.TryAddEnumerable(ServiceDescriptor.Transient<IConfigureOptions<MvcOptions>, MvcOptionsSetup>());
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IWebHookMetadata, GitHubMetadata>());
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IWebHookEventMetadata, GitHubMetadata>());
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IWebHookPingRequestMetadata, GitHubMetadata>());
 
             services.TryAddSingleton<GitHubVerifySignatureFilter>();
         }

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Kudu/Internal/KuduServiceCollectionSetup.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Kudu/Internal/KuduServiceCollectionSetup.cs
@@ -1,10 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.AspNetCore.WebHooks.Metadata;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.AspNetCore.WebHooks.Internal
 {
@@ -24,7 +23,7 @@ namespace Microsoft.AspNetCore.WebHooks.Internal
                 throw new ArgumentNullException(nameof(services));
             }
 
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IWebHookMetadata, KuduMetadata>());
+            WebHookMetadata.Register<KuduMetadata>(services);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.MailChimp/Internal/MailChimpServiceCollectionSetup.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.MailChimp/Internal/MailChimpServiceCollectionSetup.cs
@@ -1,10 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.AspNetCore.WebHooks.Metadata;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.AspNetCore.WebHooks.Internal
 {
@@ -24,7 +23,7 @@ namespace Microsoft.AspNetCore.WebHooks.Internal
                 throw new ArgumentNullException(nameof(services));
             }
 
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IWebHookMetadata, MailChimpMetadata>());
+            WebHookMetadata.Register<MailChimpMetadata>(services);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Pusher/Internal/PusherServiceCollectionSetup.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Pusher/Internal/PusherServiceCollectionSetup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.WebHooks.Internal
             }
 
             services.TryAddEnumerable(ServiceDescriptor.Transient<IConfigureOptions<MvcOptions>, MvcOptionsSetup>());
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IWebHookMetadata, PusherMetadata>());
+            WebHookMetadata.Register<PusherMetadata>(services);
 
             services.TryAddSingleton<PusherVerifySignatureFilter>();
         }

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/Internal/SalesforceServiceCollectionSetup.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/Internal/SalesforceServiceCollectionSetup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.WebHooks.Internal
             }
 
             services.TryAddEnumerable(ServiceDescriptor.Transient<IConfigureOptions<MvcOptions>, MvcOptionsSetup>());
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IWebHookMetadata, SalesforceMetadata>());
+            WebHookMetadata.Register<SalesforceMetadata>(services);
             services.TryAddSingleton<ISalesforceResultCreator, SalesforceResultCreator>();
 
             services.TryAddSingleton<SalesforceVerifyOrganizationIdFilter>();

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/Internal/SlackServiceCollectionSetup.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/Internal/SlackServiceCollectionSetup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.WebHooks.Internal
             }
 
             services.TryAddEnumerable(ServiceDescriptor.Transient<IConfigureOptions<MvcOptions>, MvcOptionsSetup>());
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IWebHookMetadata, SlackMetadata>());
+            WebHookMetadata.Register<SlackMetadata>(services);
 
             services.TryAddSingleton<SlackVerifyTokenFilter>();
         }

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Stripe/Internal/StripeServiceCollectionSetup.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Stripe/Internal/StripeServiceCollectionSetup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.WebHooks.Internal
             }
 
             services.TryAddEnumerable(ServiceDescriptor.Transient<IConfigureOptions<MvcOptions>, MvcOptionsSetup>());
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IWebHookMetadata, StripeMetadata>());
+            WebHookMetadata.Register<StripeMetadata>(services);
 
             services.TryAddSingleton<StripeTestEventRequestFilter>();
             services.TryAddSingleton<StripeVerifyNotificationIdFilter>();

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Trello/Internal/TrelloServiceCollectionSetup.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Trello/Internal/TrelloServiceCollectionSetup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.WebHooks.Internal
             }
 
             services.TryAddEnumerable(ServiceDescriptor.Transient<IConfigureOptions<MvcOptions>, MvcOptionsSetup>());
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IWebHookMetadata, TrelloMetadata>());
+            WebHookMetadata.Register<TrelloMetadata>(services);
 
             services.TryAddSingleton<TrelloVerifySignatureFilter>();
         }

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.WordPress/Internal/WordPressServiceCollectionSetup.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.WordPress/Internal/WordPressServiceCollectionSetup.cs
@@ -1,10 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.AspNetCore.WebHooks.Metadata;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.AspNetCore.WebHooks.Internal
 {
@@ -24,7 +23,7 @@ namespace Microsoft.AspNetCore.WebHooks.Internal
                 throw new ArgumentNullException(nameof(services));
             }
 
-            services.TryAddEnumerable(ServiceDescriptor.Singleton<IWebHookMetadata, WordPressMetadata>());
+            WebHookMetadata.Register<WordPressMetadata>(services);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookGetHeadRequestFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookGetHeadRequestFilter.cs
@@ -31,6 +31,9 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
         /// <param name="configuration">
         /// The <see cref="IConfiguration"/> used to initialize <see cref="WebHookSecurityFilter.Configuration"/>.
         /// </param>
+        /// <param name="getHeadRequestMetadata">
+        /// The collection of <see cref="IWebHookGetHeadRequestMetadata"/> services.
+        /// </param>
         /// <param name="hostingEnvironment">
         /// The <see cref="IHostingEnvironment" /> used to initialize
         /// <see cref="WebHookSecurityFilter.HostingEnvironment"/>.
@@ -38,15 +41,14 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to initialize <see cref="WebHookSecurityFilter.Logger"/>.
         /// </param>
-        /// <param name="metadata">The collection of <see cref="IWebHookMetadata"/> services.</param>
         public WebHookGetHeadRequestFilter(
             IConfiguration configuration,
+            IEnumerable<IWebHookGetHeadRequestMetadata> getHeadRequestMetadata,
             IHostingEnvironment hostingEnvironment,
-            ILoggerFactory loggerFactory,
-            IEnumerable<IWebHookMetadata> metadata)
+            ILoggerFactory loggerFactory)
             : base(configuration, hostingEnvironment, loggerFactory)
         {
-            _getHeadRequestMetadata = metadata.OfType<IWebHookGetHeadRequestMetadata>().ToArray();
+            _getHeadRequestMetadata = getHeadRequestMetadata.ToArray();
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookReceiverExistsFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookReceiverExistsFilter.cs
@@ -23,18 +23,21 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
     /// </summary>
     public class WebHookReceiverExistsFilter : IResourceFilter
     {
-        private readonly IReadOnlyList<IWebHookVerifyCodeMetadata> _codeVerifierMetadata;
+        private readonly IReadOnlyList<IWebHookVerifyCodeMetadata> _verifyCodeMetadata;
         private readonly ILogger _logger;
 
         /// <summary>
-        /// Instantiates a new <see cref="WebHookReceiverExistsFilter"/> with the given
-        /// <paramref name="loggerFactory"/>.
+        /// Instantiates a new <see cref="WebHookReceiverExistsFilter"/> instance.
         /// </summary>
-        /// <param name="metadata">The collection of <see cref="IWebHookMetadata"/> services.</param>
+        /// <param name="verifyCodeMetadata">
+        /// The collection of <see cref="IWebHookVerifyCodeMetadata"/> services.
+        /// </param>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
-        public WebHookReceiverExistsFilter(IEnumerable<IWebHookMetadata> metadata, ILoggerFactory loggerFactory)
+        public WebHookReceiverExistsFilter(
+            IEnumerable<IWebHookVerifyCodeMetadata> verifyCodeMetadata,
+            ILoggerFactory loggerFactory)
         {
-            _codeVerifierMetadata = metadata.OfType<IWebHookVerifyCodeMetadata>().ToArray();
+            _verifyCodeMetadata = verifyCodeMetadata.ToArray();
             _logger = loggerFactory.CreateLogger<WebHookReceiverExistsFilter>();
         }
 
@@ -82,7 +85,7 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
                 }
 
                 // Check for receiver-specific filters only for receivers that do _not_ use code verification.
-                if (!_codeVerifierMetadata.Any(metadata => metadata.IsApplicable(receiverName)))
+                if (!_verifyCodeMetadata.Any(metadata => metadata.IsApplicable(receiverName)))
                 {
                     var found = false;
                     for (var i = 0; i < context.Filters.Count; i++)

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookVerifyCodeFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookVerifyCodeFilter.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
     /// </summary>
     public class WebHookVerifyCodeFilter : WebHookSecurityFilter, IResourceFilter
     {
-        private readonly IReadOnlyList<IWebHookVerifyCodeMetadata> _codeVerifierMetadata;
+        private readonly IReadOnlyList<IWebHookVerifyCodeMetadata> _verifyCodeMetadata;
 
         /// <summary>
         /// Instantiates a new <see cref="WebHookVerifyCodeFilter"/> instance.
@@ -37,18 +37,20 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
         /// The <see cref="IHostingEnvironment" /> used to initialize
         /// <see cref="WebHookSecurityFilter.HostingEnvironment"/>.
         /// </param>
+        /// <param name="verifyCodeMetadata">
+        /// The collection of <see cref="IWebHookVerifyCodeMetadata"/> services.
+        /// </param>
         /// <param name="loggerFactory">
         /// The <see cref="ILoggerFactory"/> used to initialize <see cref="WebHookSecurityFilter.Logger"/>.
         /// </param>
-        /// <param name="metadata">The collection of <see cref="IWebHookMetadata"/> services.</param>
         public WebHookVerifyCodeFilter(
             IConfiguration configuration,
             IHostingEnvironment hostingEnvironment,
-            ILoggerFactory loggerFactory,
-            IEnumerable<IWebHookMetadata> metadata)
+            IEnumerable<IWebHookVerifyCodeMetadata> verifyCodeMetadata,
+            ILoggerFactory loggerFactory)
             : base(configuration, hostingEnvironment, loggerFactory)
         {
-            _codeVerifierMetadata = metadata.OfType<IWebHookVerifyCodeMetadata>().ToArray();
+            _verifyCodeMetadata = verifyCodeMetadata.ToArray();
         }
 
         /// <inheritdoc />
@@ -61,7 +63,7 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
 
             var routeData = context.RouteData;
             if (routeData.TryGetWebHookReceiverName(out var receiverName) &&
-                _codeVerifierMetadata.Any(metadata => metadata.IsApplicable(receiverName)))
+                _verifyCodeMetadata.Any(metadata => metadata.IsApplicable(receiverName)))
             {
                 var result = EnsureValidCode(context.HttpContext.Request, routeData, receiverName);
                 if (result != null)

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookVerifyRequiredValueFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookVerifyRequiredValueFilter.cs
@@ -34,18 +34,20 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
     /// </remarks>
     public class WebHookVerifyRequiredValueFilter : IResourceFilter
     {
-        private readonly ILogger _logger;
         private readonly IReadOnlyList<IWebHookBindingMetadata> _bindingMetadata;
+        private readonly ILogger _logger;
 
         /// <summary>
         /// Instantiates a new <see cref="WebHookVerifyRequiredValueFilter"/> instance.
         /// </summary>
+        /// <param name="bindingMetadata">The collection of <see cref="IWebHookBindingMetadata"/> services.</param>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
-        /// <param name="metadata">The collection of <see cref="IWebHookMetadata"/> services.</param>
-        public WebHookVerifyRequiredValueFilter(ILoggerFactory loggerFactory, IEnumerable<IWebHookMetadata> metadata)
+        public WebHookVerifyRequiredValueFilter(
+            IEnumerable<IWebHookBindingMetadata> bindingMetadata,
+            ILoggerFactory loggerFactory)
         {
+            _bindingMetadata = bindingMetadata.ToArray();
             _logger = loggerFactory.CreateLogger<WebHookVerifyRequiredValueFilter>();
-            _bindingMetadata = metadata.OfType<IWebHookBindingMetadata>().ToArray();
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Metadata/WebHookMetadata.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Metadata/WebHookMetadata.cs
@@ -3,6 +3,8 @@
 
 using System;
 using Microsoft.AspNetCore.WebHooks.Properties;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.AspNetCore.WebHooks.Metadata
 {
@@ -42,6 +44,49 @@ namespace Microsoft.AspNetCore.WebHooks.Metadata
             }
 
             return string.Equals(ReceiverName, receiverName, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Register <typeparamref name="TService"/> as all metadata interfaces it implements (always including
+        /// <see cref="IWebHookBodyTypeMetadataService"/>) in <paramref name="services"/>.
+        /// </summary>
+        /// <typeparam name="TService">The <see cref="IWebHookMetadata"/> type to register.</typeparam>
+        /// <param name="services">The <see cref="IServiceCollection"/> to update.</param>
+        public static void Register<TService>(IServiceCollection services)
+            where TService : class, IWebHookBodyTypeMetadataService
+        {
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IWebHookBodyTypeMetadataService, TService>());
+
+            var type = typeof(TService);
+            if (typeof(IWebHookBindingMetadata).IsAssignableFrom(type))
+            {
+                services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IWebHookBindingMetadata), type));
+            }
+
+            if (typeof(IWebHookEventFromBodyMetadata).IsAssignableFrom(type))
+            {
+                services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IWebHookEventFromBodyMetadata), type));
+            }
+
+            if (typeof(IWebHookEventMetadata).IsAssignableFrom(type))
+            {
+                services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IWebHookEventMetadata), type));
+            }
+
+            if (typeof(IWebHookGetHeadRequestMetadata).IsAssignableFrom(type))
+            {
+                services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IWebHookGetHeadRequestMetadata), type));
+            }
+
+            if (typeof(IWebHookPingRequestMetadata).IsAssignableFrom(type))
+            {
+                services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IWebHookPingRequestMetadata), type));
+            }
+
+            if (typeof(IWebHookVerifyCodeMetadata).IsAssignableFrom(type))
+            {
+                services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IWebHookVerifyCodeMetadata), type));
+            }
         }
     }
 }

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookEventMapperConstraint.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookEventMapperConstraint.cs
@@ -26,14 +26,15 @@ namespace Microsoft.AspNetCore.WebHooks.Routing
         private readonly ILogger _logger;
 
         /// <summary>
-        /// Instantiates a new <see cref="WebHookEventMapperConstraint"/> instance with the given
-        /// <paramref name="loggerFactory"/> and <paramref name="metadata"/>.
+        /// Instantiates a new <see cref="WebHookEventMapperConstraint"/> instance.
         /// </summary>
+        /// <param name="eventMetadata">The collection of <see cref="IWebHookEventMetadata"/> services.</param>
         /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
-        /// <param name="metadata">The collection of <see cref="IWebHookMetadata"/> services.</param>
-        public WebHookEventMapperConstraint(ILoggerFactory loggerFactory, IEnumerable<IWebHookMetadata> metadata)
+        public WebHookEventMapperConstraint(
+            IEnumerable<IWebHookEventMetadata> eventMetadata,
+            ILoggerFactory loggerFactory)
         {
-            _eventMetadata = metadata.OfType<IWebHookEventMetadata>().ToArray();
+            _eventMetadata = eventMetadata.ToArray();
             _logger = loggerFactory.CreateLogger<WebHookEventMapperConstraint>();
         }
 


### PR DESCRIPTION
- #179
- add `WebHookMetadata.Register<TService>(IServiceCollection services)` helper
- temporarily **breaks GitHub** scenarios; real `IWebHookBodyTypeMetadataService` requirement coming in #254

nits:
- make a few field and parameter names more specific
- simplify constructor comments for affected services
- reorder parameters for consistency