### PR TITLE
Use new ASP.NET Core 2.1 features

### DIFF
--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.AzureAlert/AzureAlertWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.AzureAlert/AzureAlertWebHookAttribute.cs
@@ -1,13 +1,19 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.WebHooks.Filters;
 
 namespace Microsoft.AspNetCore.WebHooks
 {
     /// <summary>
     /// <para>
-    /// An <see cref="System.Attribute"/> indicating the associated action is an Azure Alert WebHook endpoint.
-    /// Specifies the optional <see cref="WebHookAttribute.Id"/>. Also adds a
-    /// <see cref="Filters.WebHookReceiverExistsFilter"/> for the action.
+    /// An <see cref="Attribute"/> indicating the associated action is an Azure Alert WebHook endpoint. Specifies the
+    /// optional <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="WebHookReceiverExistsFilter"/> and a
+    /// <see cref="ModelStateInvalidFilter"/> (unless <see cref="ApiBehaviorOptions.SuppressModelStateInvalidFilter"/>
+    /// is <see langword="true"/>) for the action.
     /// </para>
     /// <para>
     /// The signature of the action should be:

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.BitBucket/BitbucketWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.BitBucket/BitbucketWebHookAttribute.cs
@@ -1,7 +1,10 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.WebHooks.Filters;
 using Microsoft.AspNetCore.WebHooks.Metadata;
 using Microsoft.AspNetCore.WebHooks.Properties;
 
@@ -9,9 +12,10 @@ namespace Microsoft.AspNetCore.WebHooks
 {
     /// <summary>
     /// <para>
-    /// An <see cref="Attribute"/> indicating the associated action is a Bitbucket WebHook endpoint.
-    /// Specifies the optional <see cref="WebHookAttribute.Id"/> and <see cref="EventName"/>. Also adds a
-    /// <see cref="Filters.WebHookReceiverExistsFilter"/> for the action.
+    /// An <see cref="Attribute"/> indicating the associated action is a Bitbucket WebHook endpoint. Specifies the
+    /// optional <see cref="EventName"/> and <see cref="WebHookAttribute.Id"/>. Also adds a
+    /// <see cref="WebHookReceiverExistsFilter"/> and a <see cref="ModelStateInvalidFilter"/> (unless
+    /// <see cref="ApiBehaviorOptions.SuppressModelStateInvalidFilter"/> is <see langword="true"/>) for the action.
     /// </para>
     /// <para>
     /// The signature of the action should be:

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Dropbox/DropboxWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Dropbox/DropboxWebHookAttribute.cs
@@ -1,13 +1,19 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.WebHooks.Filters;
 
 namespace Microsoft.AspNetCore.WebHooks
 {
     /// <summary>
     /// <para>
-    /// An <see cref="System.Attribute"/> indicating the associated action is a Dropbox WebHook endpoint. Specifies the
-    /// optional <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="Filters.WebHookReceiverExistsFilter"/> for
-    /// the action.
+    /// An <see cref="Attribute"/> indicating the associated action is a Dropbox WebHook endpoint. Specifies the
+    /// optional <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="WebHookReceiverExistsFilter"/> and a
+    /// <see cref="ModelStateInvalidFilter"/> (unless <see cref="ApiBehaviorOptions.SuppressModelStateInvalidFilter"/>
+    /// is <see langword="true"/>) for the action.
     /// </para>
     /// <para>
     /// The signature of the action should be:

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.DynamicsCRM/DynamicsCRMWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.DynamicsCRM/DynamicsCRMWebHookAttribute.cs
@@ -1,13 +1,19 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.WebHooks.Filters;
 
 namespace Microsoft.AspNetCore.WebHooks
 {
     /// <summary>
     /// <para>
-    /// An <see cref="System.Attribute"/> indicating the associated action is a Dynamics CRM WebHook endpoint.
-    /// Specifies the optional <see cref="WebHookAttribute.Id"/>. Also adds a
-    /// <see cref="Filters.WebHookReceiverExistsFilter"/> for the action.
+    /// An <see cref="Attribute"/> indicating the associated action is a Dynamics CRM WebHook endpoint.
+    /// Specifies the optional <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="WebHookReceiverExistsFilter"/>
+    /// and a <see cref="ModelStateInvalidFilter"/> (unless
+    /// <see cref="ApiBehaviorOptions.SuppressModelStateInvalidFilter"/> is <see langword="true"/>) for the action.
     /// </para>
     /// <para>
     /// The signature of the action should be:

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.GitHub/GitHubWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.GitHub/GitHubWebHookAttribute.cs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.WebHooks.Filters;
 using Microsoft.AspNetCore.WebHooks.Metadata;
 using Microsoft.AspNetCore.WebHooks.Properties;
 
@@ -10,8 +13,9 @@ namespace Microsoft.AspNetCore.WebHooks
     /// <summary>
     /// <para>
     /// An <see cref="Attribute"/> indicating the associated action is a GitHub WebHook endpoint. Specifies the
-    /// optional <see cref="EventName"/> and optional <see cref="WebHookAttribute.Id"/>. Also adds a
-    /// <see cref="Filters.WebHookReceiverExistsFilter"/> for the action.
+    /// optional <see cref="EventName"/> and <see cref="WebHookAttribute.Id"/>. Also adds a
+    /// <see cref="WebHookReceiverExistsFilter"/> and a <see cref="ModelStateInvalidFilter"/> (unless
+    /// <see cref="ApiBehaviorOptions.SuppressModelStateInvalidFilter"/> is <see langword="true"/>) for the action.
     /// </para>
     /// <para>
     /// The signature of the action should be:

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Kudu/KuduWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Kudu/KuduWebHookAttribute.cs
@@ -1,13 +1,19 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.WebHooks.Filters;
 
 namespace Microsoft.AspNetCore.WebHooks
 {
     /// <summary>
     /// <para>
-    /// An <see cref="System.Attribute"/> indicating the associated action is a Kudu WebHook endpoint. Specifies the
-    /// optional <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="Filters.WebHookReceiverExistsFilter"/> for
-    /// the action.
+    /// An <see cref="Attribute"/> indicating the associated action is a Kudu WebHook endpoint. Specifies the
+    /// optional <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="WebHookReceiverExistsFilter"/> and a
+    /// <see cref="ModelStateInvalidFilter"/> (unless <see cref="ApiBehaviorOptions.SuppressModelStateInvalidFilter"/>
+    /// is <see langword="true"/>) for the action.
     /// </para>
     /// <para>
     /// The signature of the action should be:

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.MailChimp/MailChimpWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.MailChimp/MailChimpWebHookAttribute.cs
@@ -1,13 +1,19 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.WebHooks.Filters;
 
 namespace Microsoft.AspNetCore.WebHooks
 {
     /// <summary>
     /// <para>
-    /// An <see cref="System.Attribute"/> indicating the associated action is a MailChimp WebHook endpoint. Specifies
-    /// the optional <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="Filters.WebHookReceiverExistsFilter"/>
-    /// for the action.
+    /// An <see cref="Attribute"/> indicating the associated action is a MailChimp WebHook endpoint. Specifies
+    /// the optional <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="WebHookReceiverExistsFilter"/> and a
+    /// <see cref="ModelStateInvalidFilter"/> (unless <see cref="ApiBehaviorOptions.SuppressModelStateInvalidFilter"/>
+    /// is <see langword="true"/>) for the action.
     /// </para>
     /// <para>
     /// The signature of the action should be:

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Pusher/PusherWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Pusher/PusherWebHookAttribute.cs
@@ -1,13 +1,19 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.WebHooks.Filters;
 
 namespace Microsoft.AspNetCore.WebHooks
 {
     /// <summary>
     /// <para>
-    /// An <see cref="System.Attribute"/> indicating the associated action is a Pusher WebHook endpoint. Specifies the
-    /// optional <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="Filters.WebHookReceiverExistsFilter"/> for
-    /// the action.
+    /// An <see cref="Attribute"/> indicating the associated action is a Pusher WebHook endpoint. Specifies the
+    /// optional <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="WebHookReceiverExistsFilter"/> and a
+    /// <see cref="ModelStateInvalidFilter"/> (unless <see cref="ApiBehaviorOptions.SuppressModelStateInvalidFilter"/>
+    /// is <see langword="true"/>) for the action.
     /// </para>
     /// <para>
     /// The signature of the action should be:

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/SalesforceWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/SalesforceWebHookAttribute.cs
@@ -1,13 +1,19 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.WebHooks.Filters;
 
 namespace Microsoft.AspNetCore.WebHooks
 {
     /// <summary>
     /// <para>
-    /// An <see cref="System.Attribute"/> indicating the associated action is a Salesforce WebHook endpoint. Specifies
-    /// the optional <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="Filters.WebHookReceiverExistsFilter"/>
-    /// for the action.
+    /// An <see cref="Attribute"/> indicating the associated action is a Salesforce WebHook endpoint. Specifies the
+    /// optional <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="WebHookReceiverExistsFilter"/> and a
+    /// <see cref="ModelStateInvalidFilter"/> (unless <see cref="ApiBehaviorOptions.SuppressModelStateInvalidFilter"/>
+    /// is <see langword="true"/>) for the action.
     /// </para>
     /// <para>
     /// The signature of the action should be:

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/SlackWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Slack/SlackWebHookAttribute.cs
@@ -6,15 +6,19 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.WebHooks.Filters;
 
 namespace Microsoft.AspNetCore.WebHooks
 {
     /// <summary>
     /// <para>
     /// An <see cref="Attribute"/> indicating the associated action is a Slack WebHook endpoint. Specifies the optional
-    /// <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="Filters.WebHookReceiverExistsFilter"/> for the
-    /// action and delegates its <see cref="IResultFilter"/> <see cref="IApiResponseMetadataProvider"/> implementations
-    /// to a <see cref="ProducesAttribute"/>, indicating the action produces JSON-formatted responses.
+    /// <see cref="WebHookAttribute.Id"/>. Adds a <see cref="WebHookReceiverExistsFilter"/> and a
+    /// <see cref="ModelStateInvalidFilter"/> (unless <see cref="ApiBehaviorOptions.SuppressModelStateInvalidFilter"/>
+    /// is <see langword="true"/>) for the action. Also delegates its <see cref="IResultFilter"/> and
+    /// <see cref="IApiResponseMetadataProvider"/> implementations to a <see cref="ProducesAttribute"/>, indicating the
+    /// action produces JSON-formatted responses.
     /// </para>
     /// <para>
     /// The signature of the action should be:

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Stripe/StripeWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Stripe/StripeWebHookAttribute.cs
@@ -1,13 +1,19 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.WebHooks.Filters;
 
 namespace Microsoft.AspNetCore.WebHooks
 {
     /// <summary>
     /// <para>
-    /// An <see cref="System.Attribute"/> indicating the associated action is a Stripe WebHook endpoint. Specifies the
-    /// optional <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="Filters.WebHookReceiverExistsFilter"/> for
-    /// the action.
+    /// An <see cref="Attribute"/> indicating the associated action is a Stripe WebHook endpoint. Specifies the
+    /// optional <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="WebHookReceiverExistsFilter"/> and a
+    /// <see cref="ModelStateInvalidFilter"/> (unless <see cref="ApiBehaviorOptions.SuppressModelStateInvalidFilter"/>
+    /// is <see langword="true"/>) for the action.
     /// </para>
     /// <para>
     /// The signature of the action should be:

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Trello/TrelloWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Trello/TrelloWebHookAttribute.cs
@@ -1,15 +1,19 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.WebHooks.Filters;
 
 namespace Microsoft.AspNetCore.WebHooks
 {
     /// <summary>
     /// <para>
     /// An <see cref="Attribute"/> indicating the associated action is a Trello WebHook endpoint. Specifies the
-    /// optional <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="Filters.WebHookReceiverExistsFilter"/> for
-    /// the action.
+    /// optional <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="WebHookReceiverExistsFilter"/> and a
+    /// <see cref="ModelStateInvalidFilter"/> (unless <see cref="ApiBehaviorOptions.SuppressModelStateInvalidFilter"/>
+    /// is <see langword="true"/>) for the action.
     /// </para>
     /// <para>
     /// The signature of the action should be:

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.WordPress/WordPressWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.WordPress/WordPressWebHookAttribute.cs
@@ -1,13 +1,19 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.WebHooks.Filters;
 
 namespace Microsoft.AspNetCore.WebHooks
 {
     /// <summary>
     /// <para>
-    /// An <see cref="System.Attribute"/> indicating the associated action is a WordPress WebHook endpoint.
-    /// Specifies the optional <see cref="WebHookAttribute.Id"/>. Also adds a
-    /// <see cref="Filters.WebHookReceiverExistsFilter"/> for the action.
+    /// An <see cref="Attribute"/> indicating the associated action is a WordPress WebHook endpoint. Specifies the
+    /// optional <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="WebHookReceiverExistsFilter"/> and a
+    /// <see cref="ModelStateInvalidFilter"/> (unless <see cref="ApiBehaviorOptions.SuppressModelStateInvalidFilter"/>
+    /// is <see langword="true"/>) for the action.
     /// </para>
     /// <para>
     /// The signature of the action should be:

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/ApplicationModels/WebHookFilterProvider.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/ApplicationModels/WebHookFilterProvider.cs
@@ -1,0 +1,134 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.WebHooks.Filters;
+using Microsoft.AspNetCore.WebHooks.Metadata;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.WebHooks.ApplicationModels
+{
+    /// <summary>
+    /// An <see cref="IApplicationModelProvider"/> implementation that adds a <see cref="WebHookVerifyBodyTypeFilter"/>
+    /// and a <see cref="ModelStateInvalidFilter"/> (unless
+    /// <see cref="ApiBehaviorOptions.SuppressModelStateInvalidFilter"/> is <see langword="true"/>) filter to the
+    /// <see cref="ActionModel.Filters"/> collections of WebHook actions.
+    /// </summary>
+    public class WebHookFilterProvider : IApplicationModelProvider
+    {
+        private readonly ApiBehaviorOptions _behaviorOptions;
+        private readonly ILoggerFactory _loggerFactory;
+        private readonly ModelStateInvalidFilter _modelStateInvalidFilter;
+
+        /// <summary>
+        /// Instantiates a new <see cref="WebHookFilterProvider"/> instance with the given
+        /// <paramref name="behaviorOptions"/> and <paramref name="loggerFactory"/>.
+        /// </summary>
+        /// <param name="behaviorOptions">The <see cref="ApiBehaviorOptions"/> accessor.</param>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
+        public WebHookFilterProvider(IOptions<ApiBehaviorOptions> behaviorOptions, ILoggerFactory loggerFactory)
+        {
+            _behaviorOptions = behaviorOptions.Value;
+            _loggerFactory = loggerFactory;
+
+            var logger = loggerFactory.CreateLogger<ModelStateInvalidFilter>();
+            _modelStateInvalidFilter = new ModelStateInvalidFilter(_behaviorOptions, logger);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IApplicationModelProvider.Order"/> value used in all
+        /// <see cref="WebHookFilterProvider"/> instances. The WebHook <see cref="IApplicationModelProvider"/> order
+        /// is
+        /// <list type="number">
+        /// <item>
+        /// Add <see cref="IWebHookMetadata"/> references to the <see cref="ActionModel.Properties"/> collections of
+        /// WebHook actions and validate those <see cref="IWebHookMetadata"/> attributes and services (in
+        /// <see cref="WebHookMetadataProvider"/>).
+        /// </item>
+        /// <item>
+        /// Add routing information (<see cref="SelectorModel"/> settings) to <see cref="ActionModel"/>s of WebHook
+        /// actions (in <see cref="WebHookRoutingProvider"/>).
+        /// </item>
+        /// <item>
+        /// Add filters to the <see cref="ActionModel.Filters"/> collections of WebHook actions (in this provider).
+        /// </item>
+        /// <item>
+        /// Add model binding information (<see cref="BindingInfo"/> settings) to <see cref="ParameterModel"/>s of
+        /// WebHook actions (in <see cref="WebHookModelBindingProvider"/>).
+        /// </item>
+        /// </list>
+        /// </summary>
+        public static int Order => WebHookRoutingProvider.Order + 10;
+
+        /// <inheritdoc />
+        int IApplicationModelProvider.Order => Order;
+
+        /// <inheritdoc />
+        public void OnProvidersExecuting(ApplicationModelProviderContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            for (var i = 0; i < context.Result.Controllers.Count; i++)
+            {
+                var controller = context.Result.Controllers[i];
+                for (var j = 0; j < controller.Actions.Count; j++)
+                {
+                    var action = controller.Actions[j];
+                    Apply(action);
+                }
+            }
+        }
+
+        /// <inheritdoc />
+        public void OnProvidersExecuted(ApplicationModelProviderContext context)
+        {
+            // No-op
+        }
+
+
+        private void Apply(ActionModel action)
+        {
+            var attribute = action.Attributes.OfType<WebHookAttribute>().FirstOrDefault();
+            if (attribute == null)
+            {
+                // Not a WebHook handler.
+                return;
+            }
+
+            var filters = action.Filters;
+            AddVerifyBodyFilter(action.Properties, filters);
+            if (!_behaviorOptions.SuppressModelStateInvalidFilter)
+            {
+                filters.Add(_modelStateInvalidFilter);
+            }
+        }
+
+        private void AddVerifyBodyFilter(IDictionary<object, object> properties, IList<IFilterMetadata> filters)
+        {
+            WebHookVerifyBodyTypeFilter filter;
+            var bodyTypeMetadataObject = properties[typeof(IWebHookBodyTypeMetadataService)];
+            if (bodyTypeMetadataObject is IWebHookBodyTypeMetadataService receiverBodyTypeMetadata)
+            {
+                filter = new WebHookVerifyBodyTypeFilter(receiverBodyTypeMetadata, _loggerFactory);
+            }
+            else
+            {
+                var allBodyTypeMetadata = (IReadOnlyList<IWebHookBodyTypeMetadataService>)bodyTypeMetadataObject;
+                filter = new WebHookVerifyBodyTypeFilter(allBodyTypeMetadata, _loggerFactory);
+            }
+
+            filters.Add(filter);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/ApplicationModels/WebHookMetadataProvider.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/ApplicationModels/WebHookMetadataProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.WebHooks.Metadata;
 using Microsoft.AspNetCore.WebHooks.Properties;
 
@@ -14,11 +15,12 @@ namespace Microsoft.AspNetCore.WebHooks.ApplicationModels
     /// <summary>
     /// <para>
     /// An <see cref="IApplicationModelProvider"/> implementation that adds <see cref="IWebHookMetadata"/>
-    /// references to WebHook <see cref="ActionModel"/>s. Metadata is stored in <see cref="ActionModel.Properties"/>
-    /// and used in <see cref="WebHookModelBindingProvider"/> and <see cref="WebHookRoutingProvider"/>.
+    /// references to <see cref="ActionModel.Properties"/> collections of WebHook actions. Later WebHook
+    /// <see cref="IApplicationModelProvider"/> implementations (<see cref="WebHookFilterProvider"/>,
+    /// <see cref="WebHookModelBindingProvider"/> and <see cref="WebHookRoutingProvider"/>) use this metadata.
     /// </para>
     /// <para>
-    /// Detects missing and duplicate <see cref="IWebHookMetadata"/> services.
+    /// Detects duplicate, missing and invalid <see cref="IWebHookMetadata"/> attributes and services.
     /// </para>
     /// </summary>
     public class WebHookMetadataProvider : IApplicationModelProvider
@@ -100,20 +102,25 @@ namespace Microsoft.AspNetCore.WebHooks.ApplicationModels
 
         /// <summary>
         /// Gets the <see cref="IApplicationModelProvider.Order"/> value used in all
-        /// <see cref="WebHookMetadataProvider"/> instances. The recommended <see cref="IApplicationModelProvider"/>
-        /// order is
+        /// <see cref="WebHookMetadataProvider"/> instances. The WebHook <see cref="IApplicationModelProvider"/> order
+        /// is
         /// <list type="number">
         /// <item>
-        /// Validate metadata services and <see cref="WebHookAttribute"/> metadata implementations and add information
-        /// used in later application model providers (in this provider).
+        /// Add <see cref="IWebHookMetadata"/> references to the <see cref="ActionModel.Properties"/> collections of
+        /// WebHook actions and validate those <see cref="IWebHookMetadata"/> attributes and services (in this
+        /// provider).
         /// </item>
         /// <item>
-        /// Add routing information (template, constraints and filters) to <see cref="ActionModel"/>s (in
-        /// <see cref="WebHookRoutingProvider"/>).
+        /// Add routing information (<see cref="SelectorModel"/> settings) to <see cref="ActionModel"/>s of WebHook
+        /// actions (in <see cref="WebHookRoutingProvider"/>).
         /// </item>
         /// <item>
-        /// Add model binding information (<see cref="Mvc.ModelBinding.BindingInfo"/> settings) to
-        /// <see cref="ParameterModel"/>s (in <see cref="WebHookModelBindingProvider"/>).
+        /// Add filters to the <see cref="ActionModel.Filters"/> collections of WebHook actions (in
+        /// <see cref="WebHookFilterProvider"/>).
+        /// </item>
+        /// <item>
+        /// Add model binding information (<see cref="BindingInfo"/> settings) to <see cref="ParameterModel"/>s of
+        /// WebHook actions (in <see cref="WebHookModelBindingProvider"/>).
         /// </item>
         /// </list>
         /// </summary>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/ApplicationModels/WebHookModelBindingProvider.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/ApplicationModels/WebHookModelBindingProvider.cs
@@ -37,24 +37,29 @@ namespace Microsoft.AspNetCore.WebHooks.ApplicationModels
 
         /// <summary>
         /// Gets the <see cref="IApplicationModelProvider.Order"/> value used in all
-        /// <see cref="WebHookModelBindingProvider"/> instances. The recommended
-        /// <see cref="IApplicationModelProvider"/> order is
+        /// <see cref="WebHookModelBindingProvider"/> instances. The WebHook <see cref="IApplicationModelProvider"/>
+        /// order is
         /// <list type="number">
         /// <item>
-        /// Validate metadata services and <see cref="WebHookAttribute"/> metadata implementations and add information
-        /// used in later application model providers (in <see cref="WebHookMetadataProvider"/>).
+        /// Add <see cref="IWebHookMetadata"/> references to the <see cref="ActionModel.Properties"/> collections of
+        /// WebHook actions and validate those <see cref="IWebHookMetadata"/> attributes and services (in
+        /// <see cref="WebHookMetadataProvider"/>).
         /// </item>
         /// <item>
-        /// Add routing information (template, constraints and filters) to <see cref="ActionModel"/>s (in
-        /// <see cref="WebHookRoutingProvider"/>).
+        /// Add routing information (<see cref="SelectorModel"/> settings) to <see cref="ActionModel"/>s of WebHook
+        /// actions (in <see cref="WebHookRoutingProvider"/>).
         /// </item>
         /// <item>
-        /// Add model binding information (<see cref="BindingInfo"/> settings) to <see cref="ParameterModel"/>s (in
-        /// this filter).
+        /// Add filters to the <see cref="ActionModel.Filters"/> collections of WebHook actions (in
+        /// <see cref="WebHookFilterProvider"/>).
+        /// </item>
+        /// <item>
+        /// Add model binding information (<see cref="BindingInfo"/> settings) to <see cref="ParameterModel"/>s of
+        /// WebHook actions (in this provider).
         /// </item>
         /// </list>
         /// </summary>
-        public static int Order => WebHookRoutingProvider.Order + 10;
+        public static int Order => WebHookFilterProvider.Order + 10;
 
         /// <inheritdoc />
         int IApplicationModelProvider.Order => Order;

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/ApplicationModels/WebHookRoutingProvider.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/ApplicationModels/WebHookRoutingProvider.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.WebHooks.Metadata;
 using Microsoft.AspNetCore.WebHooks.Properties;
 using Microsoft.AspNetCore.WebHooks.Routing;
-using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.WebHooks.ApplicationModels
 {
@@ -25,24 +24,19 @@ namespace Microsoft.AspNetCore.WebHooks.ApplicationModels
     {
         private readonly WebHookReceiverExistsConstraint _existsConstraint;
         private readonly WebHookEventMapperConstraint _eventMapperConstraint;
-        private readonly ILoggerFactory _loggerFactory;
 
         /// <summary>
         /// Instantiates a new <see cref="WebHookRoutingProvider"/> instance with the given
-        /// <paramref name="existsConstraint"/>, <paramref name="eventMapperConstraint"/> and
-        /// <paramref name="loggerFactory"/>.
+        /// <paramref name="existsConstraint"/> and <paramref name="eventMapperConstraint"/>.
         /// </summary>
         /// <param name="existsConstraint">The <see cref="WebHookReceiverExistsConstraint"/>.</param>
         /// <param name="eventMapperConstraint">The <see cref="WebHookEventMapperConstraint"/>.</param>
-        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
         public WebHookRoutingProvider(
             WebHookReceiverExistsConstraint existsConstraint,
-            WebHookEventMapperConstraint eventMapperConstraint,
-            ILoggerFactory loggerFactory)
+            WebHookEventMapperConstraint eventMapperConstraint)
         {
             _existsConstraint = existsConstraint;
             _eventMapperConstraint = eventMapperConstraint;
-            _loggerFactory = loggerFactory;
         }
 
         /// <summary>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookVerifyBodyTypeFilter.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Filters/WebHookVerifyBodyTypeFilter.cs
@@ -34,12 +34,18 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
     /// </remarks>
     public class WebHookVerifyBodyTypeFilter : IResourceFilter, IOrderedFilter
     {
+        private static readonly MediaTypeHeaderValue ApplicationAnyJsonMediaType
+            = new MediaTypeHeaderValue("application/*+json").CopyAsReadOnly();
+        private static readonly MediaTypeHeaderValue ApplicationAnyXmlMediaType
+            = new MediaTypeHeaderValue("application/*+xml").CopyAsReadOnly();
         private static readonly MediaTypeHeaderValue ApplicationJsonMediaType
-            = new MediaTypeHeaderValue("application/json");
+            = new MediaTypeHeaderValue("application/json").CopyAsReadOnly();
         private static readonly MediaTypeHeaderValue ApplicationXmlMediaType
-            = new MediaTypeHeaderValue("application/xml");
-        private static readonly MediaTypeHeaderValue TextJsonMediaType = new MediaTypeHeaderValue("text/json");
-        private static readonly MediaTypeHeaderValue TextXmlMediaType = new MediaTypeHeaderValue("text/xml");
+            = new MediaTypeHeaderValue("application/xml").CopyAsReadOnly();
+        private static readonly MediaTypeHeaderValue TextJsonMediaType
+            = new MediaTypeHeaderValue("text/json").CopyAsReadOnly();
+        private static readonly MediaTypeHeaderValue TextXmlMediaType
+            = new MediaTypeHeaderValue("text/xml").CopyAsReadOnly();
 
         private readonly IReadOnlyList<IWebHookBodyTypeMetadataService> _allBodyTypeMetadata;
         private readonly IWebHookBodyTypeMetadataService _receiverBodyTypeMetadata;
@@ -253,16 +259,9 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
                 return false;
             }
 
-            if (contentType.IsSubsetOf(ApplicationJsonMediaType) || contentType.IsSubsetOf(TextJsonMediaType))
-            {
-                return true;
-            }
-
-            // MVC's JsonInputFormatter does not support text/*+json by default. RFC 3023 and 6839 allow */*+json but
-            // https://www.iana.org/assignments/media-types/media-types.xhtml shows all +json registrations except
-            // model/gltf+json match application/*+json.
-            return contentType.Type.Equals("application", StringComparison.OrdinalIgnoreCase) &&
-                contentType.SubType.EndsWith("+json", StringComparison.OrdinalIgnoreCase);
+            return contentType.IsSubsetOf(ApplicationJsonMediaType) ||
+                contentType.IsSubsetOf(ApplicationAnyJsonMediaType) ||
+                contentType.IsSubsetOf(TextJsonMediaType);
         }
 
         /// <summary>
@@ -282,16 +281,9 @@ namespace Microsoft.AspNetCore.WebHooks.Filters
                 return false;
             }
 
-            if (contentType.IsSubsetOf(ApplicationXmlMediaType) || contentType.IsSubsetOf(TextXmlMediaType))
-            {
-                return true;
-            }
-
-            // MVC's XML input formatters do not support text/*+xml by default. RFC 3023 and 6839 allow */*+xml but
-            // https://www.iana.org/assignments/media-types/media-types.xhtml shows almost all +xml registrations
-            // match application/*+xml and none match text/*+xml.
-            return contentType.Type.Equals("application", StringComparison.OrdinalIgnoreCase) &&
-                contentType.SubType.EndsWith("+xml", StringComparison.OrdinalIgnoreCase);
+            return contentType.IsSubsetOf(ApplicationXmlMediaType) ||
+                contentType.IsSubsetOf(ApplicationAnyXmlMediaType) ||
+                contentType.IsSubsetOf(TextXmlMediaType);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/GeneralWebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/GeneralWebHookAttribute.cs
@@ -3,6 +3,9 @@
 
 using System;
 using System.Globalization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.WebHooks.Filters;
 using Microsoft.AspNetCore.WebHooks.Metadata;
 using Microsoft.AspNetCore.WebHooks.Properties;
 
@@ -12,8 +15,9 @@ namespace Microsoft.AspNetCore.WebHooks
     /// <para>
     /// An <see cref="Attribute"/> indicating the associated action is a WebHook endpoint for all configured receivers.
     /// Specifies the expected <see cref="BodyType"/> (if any), optional <see cref="EventName"/>, and optional
-    /// <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="Filters.WebHookReceiverExistsFilter"/> for the
-    /// action.
+    /// <see cref="WebHookAttribute.Id"/>. Also adds a <see cref="WebHookReceiverExistsFilter"/> and a
+    /// <see cref="ModelStateInvalidFilter"/> (unless <see cref="ApiBehaviorOptions.SuppressModelStateInvalidFilter"/>
+    /// is <see langword="true"/>) for the action.
     /// </para>
     /// <para>
     /// The signature of the action should be:

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/WebHookAttribute.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/WebHookAttribute.cs
@@ -1,9 +1,11 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.WebHooks.Filters;
 using Microsoft.AspNetCore.WebHooks.Properties;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,7 +15,8 @@ namespace Microsoft.AspNetCore.WebHooks
     /// <summary>
     /// Base for <see cref="Attribute"/>s indicating the associated action is a WebHook endpoint. Specifies the
     /// required (in most cases) <see cref="ReceiverName"/> and optional <see cref="Id"/>. Also adds a
-    /// <see cref="WebHookReceiverExistsFilter"/> for the action.
+    /// <see cref="WebHookReceiverExistsFilter"/> and a <see cref="ModelStateInvalidFilter"/> (unless
+    /// <see cref="ApiBehaviorOptions.SuppressModelStateInvalidFilter"/> is <see langword="true"/>) for the action.
     /// </summary>
     /// <remarks>
     /// <para>


### PR DESCRIPTION
- #240
- add `ModelStateInvalidFilter` to all WebHook actions
  - add `WebHookFilterProvider` class and refactor `WebHookRoutingProvider.AddFilters(...)` to there
- use `MediaTypeHeaderValue` for subtype suffix matches

nits:
- make `MediaTypeHeaderValue`s in `WebHookVerifyBodyTypeFilter` read only
- add `using`s for namespaces used only in updated doc comments
  - VS "Remove 'n Sort" doesn't remove these anymore