### PR TITLE
Merge into `dev`: Support receiver name / id lookup from `ActionDescriptor` in constraints

### DIFF
--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Extensions/WebHookRouteDataExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Extensions/WebHookRouteDataExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -62,10 +62,9 @@ namespace Microsoft.AspNetCore.Routing
 
             if (routeData.Values.TryGetValue(WebHookConstants.EventKeyName, out var name))
             {
-                var potentialEventName = (string)name;
-                if (!string.IsNullOrEmpty(potentialEventName))
+                eventName = (string)name;
+                if (!string.IsNullOrEmpty(eventName))
                 {
-                    eventName = potentialEventName;
                     return true;
                 }
             }
@@ -141,7 +140,10 @@ namespace Microsoft.AspNetCore.Routing
             if (routeData.Values.TryGetValue(WebHookConstants.IdKeyName, out var identifier))
             {
                 id = (string)identifier;
-                return !string.IsNullOrEmpty(id);
+                if (!string.IsNullOrEmpty(id))
+                {
+                    return true;
+                }
             }
 
             id = null;
@@ -167,7 +169,10 @@ namespace Microsoft.AspNetCore.Routing
             if (routeData.Values.TryGetValue(WebHookConstants.ReceiverKeyName, out var receiver))
             {
                 receiverName = (string)receiver;
-                return !string.IsNullOrEmpty(receiverName);
+                if (!string.IsNullOrEmpty(receiverName))
+                {
+                    return true;
+                }
             }
 
             receiverName = null;

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookEventMapperConstraint.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookEventMapperConstraint.cs
@@ -57,7 +57,9 @@ namespace Microsoft.AspNetCore.WebHooks.Routing
             }
 
             var routeContext = context.RouteContext;
-            if (routeContext.RouteData.TryGetWebHookReceiverName(out var receiverName))
+            if (routeContext.RouteData.TryGetWebHookReceiverName(
+                context.CurrentCandidate.Action,
+                out var receiverName))
             {
                 var eventMetadata = _eventMetadata.FirstOrDefault(metadata => metadata.IsApplicable(receiverName));
                 if (eventMetadata != null)
@@ -128,14 +130,13 @@ namespace Microsoft.AspNetCore.WebHooks.Routing
                 return true;
             }
 
-            routeData.TryGetWebHookReceiverName(out var receiverName);
             if (eventMetadata.QueryParameterName == null)
             {
                 _logger.LogWarning(
                     0,
                     "A '{ReceiverName}' WebHook request must contain a '{HeaderName}' HTTP header " +
                     "indicating the type of event.",
-                    receiverName,
+                    eventMetadata.ReceiverName,
                     eventMetadata.HeaderName);
             }
             else if (eventMetadata.HeaderName == null)
@@ -144,7 +145,7 @@ namespace Microsoft.AspNetCore.WebHooks.Routing
                     1,
                     "A '{ReceiverName}' WebHook request must contain a '{QueryParameterKey}' query " +
                     "parameter indicating the type of event.",
-                    receiverName,
+                    eventMetadata.ReceiverName,
                     eventMetadata.QueryParameterName);
             }
             else
@@ -153,7 +154,7 @@ namespace Microsoft.AspNetCore.WebHooks.Routing
                     2,
                     "A '{ReceiverName}' WebHook request must contain a '{HeaderName}' HTTP header or a " +
                     "'{QueryParameterKey}' query parameter indicating the type of event.",
-                    receiverName,
+                    eventMetadata.ReceiverName,
                     eventMetadata.HeaderName,
                     eventMetadata.QueryParameterName);
             }

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookIdConstraint.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookIdConstraint.cs
@@ -1,9 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using Microsoft.AspNetCore.Mvc.ActionConstraints;
-using Microsoft.AspNetCore.Routing;
 
 namespace Microsoft.AspNetCore.WebHooks.Routing
 {
@@ -46,7 +45,7 @@ namespace Microsoft.AspNetCore.WebHooks.Routing
                 throw new ArgumentNullException(nameof(context));
             }
 
-            if (!context.RouteContext.RouteData.TryGetWebHookReceiverId(out var id))
+            if (!context.RouteContext.RouteData.TryGetWebHookReceiverId(context.CurrentCandidate.Action, out var id))
             {
                 return false;
             }

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookMultipleEventNamesConstraint.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookMultipleEventNamesConstraint.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc.ActionConstraints;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.WebHooks.Metadata;
 using Microsoft.AspNetCore.WebHooks.Properties;
 
@@ -53,7 +52,9 @@ namespace Microsoft.AspNetCore.WebHooks.Routing
                 throw new ArgumentNullException(nameof(context));
             }
 
-            if (context.RouteContext.RouteData.TryGetWebHookReceiverName(out var receiverName))
+            if (context.RouteContext.RouteData.TryGetWebHookReceiverName(
+                context.CurrentCandidate.Action,
+                out var receiverName))
             {
                 var pingMetadata = _pingMetadata.FirstOrDefault(metadata => metadata.IsApplicable(receiverName));
                 return Accept(context, _eventName, pingMetadata?.PingEventName);

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookReceiverExistsConstraint.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookReceiverExistsConstraint.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc.ActionConstraints;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.WebHooks.Metadata;
 
 namespace Microsoft.AspNetCore.WebHooks.Routing
@@ -47,7 +46,9 @@ namespace Microsoft.AspNetCore.WebHooks.Routing
                 throw new ArgumentNullException(nameof(context));
             }
 
-            if (!context.RouteContext.RouteData.TryGetWebHookReceiverName(out var receiverName))
+            if (!context.RouteContext.RouteData.TryGetWebHookReceiverName(
+                context.CurrentCandidate.Action,
+                out var receiverName))
             {
                 return false;
             }

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookReceiverNameConstraint.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookReceiverNameConstraint.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.AspNetCore.Mvc.ActionConstraints;
-using Microsoft.AspNetCore.Routing;
 
 namespace Microsoft.AspNetCore.WebHooks.Routing
 {
@@ -48,7 +47,9 @@ namespace Microsoft.AspNetCore.WebHooks.Routing
                 throw new ArgumentNullException(nameof(context));
             }
 
-            if (!context.RouteContext.RouteData.TryGetWebHookReceiverName(out var receiverName))
+            if (!context.RouteContext.RouteData.TryGetWebHookReceiverName(
+                context.CurrentCandidate.Action,
+                out var receiverName))
             {
                 return false;
             }

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookRouteDataActionDescriptorExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookRouteDataActionDescriptorExtensions.cs
@@ -1,0 +1,95 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Routing;
+
+namespace Microsoft.AspNetCore.WebHooks.Routing
+{
+    /// <summary>
+    /// Extension methods with <see cref="ActionDescriptor"/> parameters for the <see cref="RouteData"/> class.
+    /// </summary>
+    internal static class WebHookRouteDataActionDescriptorExtensions
+    {
+        /// <summary>
+        /// Gets the WebHook receiver id for the current request.
+        /// </summary>
+        /// <param name="routeData">The <see cref="RouteData"/> for the current request.</param>
+        /// <param name="actionDescriptor">The <see cref="ActionDescriptor"/> for the candidate action.</param>
+        /// <param name="id">Set to the id of the requested receiver.</param>
+        /// <returns>
+        /// <see langword="true"/> if a receiver id was found in the <paramref name="routeData"/> or
+        /// <paramref name="actionDescriptor"/>; <see langword="false"/> otherwise.
+        /// </returns>
+        public static bool TryGetWebHookReceiverId(
+            this RouteData routeData,
+            ActionDescriptor actionDescriptor,
+            out string id)
+        {
+            if (routeData == null)
+            {
+                throw new ArgumentNullException(nameof(routeData));
+            }
+            if (actionDescriptor == null)
+            {
+                throw new ArgumentNullException(nameof(actionDescriptor));
+            }
+
+            // Check RouteData first because we're usually dealing with the default WebHook template.
+            if (routeData.TryGetWebHookReceiverId(out id))
+            {
+                return true;
+            }
+
+            if (actionDescriptor.RouteValues.TryGetValue(WebHookConstants.IdKeyName, out id) &&
+                !string.IsNullOrEmpty(id))
+            {
+                return true;
+            }
+
+            id = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Gets the WebHook receiver name for the current request.
+        /// </summary>
+        /// <param name="routeData">The <see cref="RouteData"/> for the current request.</param>
+        /// <param name="actionDescriptor">The <see cref="ActionDescriptor"/> for the candidate action.</param>
+        /// <param name="receiverName">Set to the name of the requested receiver.</param>
+        /// <returns>
+        /// <see langword="true"/> if a receiver name was found in the <paramref name="routeData"/> or
+        /// <paramref name="actionDescriptor"/>; <see langword="false"/> otherwise.
+        /// </returns>
+        public static bool TryGetWebHookReceiverName(
+            this RouteData routeData,
+            ActionDescriptor actionDescriptor,
+            out string receiverName)
+        {
+            if (routeData == null)
+            {
+                throw new ArgumentNullException(nameof(routeData));
+            }
+            if (actionDescriptor == null)
+            {
+                throw new ArgumentNullException(nameof(actionDescriptor));
+            }
+
+            // Check RouteData first because we're usually dealing with the default WebHook template.
+            if (routeData.TryGetWebHookReceiverName(out receiverName))
+            {
+                return true;
+            }
+
+            if (actionDescriptor.RouteValues.TryGetValue(WebHookConstants.ReceiverKeyName, out receiverName) &&
+                !string.IsNullOrEmpty(receiverName))
+            {
+                return true;
+            }
+
+            receiverName = null;
+            return false;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.WebHooks.Receivers.Test/Routing/WebHookConstraintTestBase.cs
+++ b/test/Microsoft.AspNetCore.WebHooks.Receivers.Test/Routing/WebHookConstraintTestBase.cs
@@ -1,0 +1,208 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+using Microsoft.AspNetCore.Routing;
+using Xunit;
+
+namespace Microsoft.AspNetCore.WebHooks.Routing
+{
+    public abstract class WebHookConstraintTestBase
+    {
+        public static TheoryData<string> MatchingDataSet
+        {
+            get
+            {
+                return new TheoryData<string>
+                {
+                    "match",
+                    "Match",
+                    "MATCH",
+                };
+            }
+        }
+
+        public static TheoryData<string> NonMatchingDataSet
+        {
+            get
+            {
+                return new TheoryData<string>
+                {
+                    "notMatch",
+                    "matching",
+                    "another",
+                };
+            }
+        }
+
+        public static TheoryData<string> NoRequestValueDataSet
+        {
+            get
+            {
+                return new TheoryData<string>
+                {
+                    null,
+                    string.Empty,
+                };
+            }
+        }
+
+        protected abstract string KeyName { get; }
+
+        [Fact]
+        public void Accept_FailsOrNoops_OnEmpty()
+        {
+            // Arrange
+            var constraint = GetConstraint();
+            var context = GetContext(constraint);
+
+            // Act & Assert
+            ConfirmRequestValueNonMatch(context, c => constraint.Accept(c));
+        }
+
+        [Theory]
+        [MemberData(nameof(MatchingDataSet))]
+        public void Accept_Succeeds_OnActionDescriptorMatch(string requestValue)
+        {
+            // Arrange
+            var constraint = GetConstraint();
+            var context = GetContext(constraint);
+            context.CurrentCandidate.Action.RouteValues.Add(KeyName, requestValue);
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert
+            ConfirmRequestValueMatch(context, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(NonMatchingDataSet))]
+        public void Accept_FailsOrNoops_OnActionDescriptorNonMatch(string requestValue)
+        {
+            // Arrange
+            var constraint = GetConstraint();
+            var context = GetContext(constraint);
+            context.CurrentCandidate.Action.RouteValues.Add(KeyName, requestValue);
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert
+            ConfirmRequestValueNonMatch(context, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(NoRequestValueDataSet))]
+        public void Accept_FailsOrNoops_OnNoActionDescriptorRequestValue(string requestValue)
+        {
+            // Arrange
+            var constraint = GetConstraint();
+            var context = GetContext(constraint);
+            context.CurrentCandidate.Action.RouteValues.Add(KeyName, requestValue);
+
+            // Act & Assert
+            ConfirmRequestValueNonMatch(context, c => constraint.Accept(c));
+        }
+
+        // RouteContext has precedence over ActionDescsriptor.
+        [Fact]
+        public void Accept_FailsOrNoops_OnRouteContextNonMatch_ActionDescriptorMatch()
+        {
+            // Arrange
+            var constraint = GetConstraint();
+            var context = GetContext(constraint);
+            context.RouteContext.RouteData.Values.Add(KeyName, "another");
+            context.CurrentCandidate.Action.RouteValues.Add(KeyName, "match");
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert
+            ConfirmRequestValueNonMatch(context, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(MatchingDataSet))]
+        public void Accept_Succeeds_OnRouteContextMatch(string requestValue)
+        {
+            // Arrange
+            var constraint = GetConstraint();
+            var context = GetContext(constraint);
+            context.RouteContext.RouteData.Values.Add(KeyName, requestValue);
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert
+            ConfirmRequestValueMatch(context, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(NonMatchingDataSet))]
+        public void Accept_FailsOrNoops_OnRouteContextNonMatch(string requestValue)
+        {
+            // Arrange
+            var constraint = GetConstraint();
+            var context = GetContext(constraint);
+            context.RouteContext.RouteData.Values.Add(KeyName, requestValue);
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert
+            ConfirmRequestValueNonMatch(context, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(NoRequestValueDataSet))]
+        public void Accept_FailsOrNoops_OnNoRouteContextRequestValue(string requestValue)
+        {
+            // Arrange
+            var constraint = GetConstraint();
+            var context = GetContext(constraint);
+            context.RouteContext.RouteData.Values.Add(KeyName, requestValue);
+
+            // Act & Assert
+            ConfirmRequestValueNonMatch(context, c => constraint.Accept(c));
+        }
+
+        protected abstract IActionConstraint GetConstraint();
+
+        protected virtual void ConfirmRequestValueMatch(ActionConstraintContext context, bool result)
+        {
+            // Most constraints succeed by allowing action selection.
+            Assert.True(result);
+        }
+
+        protected virtual void ConfirmRequestValueNonMatch(ActionConstraintContext context, bool result)
+        {
+            // Most constraints fail by simply disallowing action selection.
+            Assert.False(result);
+        }
+
+        // Allow special cases for constraints that behave differently when request doesn't contain expected key.
+        protected virtual void ConfirmRequestValueNonMatch(
+            ActionConstraintContext context,
+            Func<ActionConstraintContext, bool> process)
+        {
+            // Act
+            var result = process(context);
+
+            // Assert
+            ConfirmRequestValueNonMatch(context, result);
+        }
+
+        protected virtual ActionConstraintContext GetContext(IActionConstraint constraint)
+        {
+            return new ActionConstraintContext
+            {
+                CurrentCandidate = new ActionSelectorCandidate(new ActionDescriptor(), new[] { constraint }),
+                RouteContext = new RouteContext(new DefaultHttpContext()),
+            };
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.WebHooks.Receivers.Test/Routing/WebHookEventMapperConstraintTests.cs
+++ b/test/Microsoft.AspNetCore.WebHooks.Receivers.Test/Routing/WebHookEventMapperConstraintTests.cs
@@ -1,0 +1,202 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+using Microsoft.AspNetCore.WebHooks.Metadata;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.WebHooks.Routing
+{
+    public class WebHookEventMapperConstraintTests : WebHookConstraintTestBase
+    {
+        protected override string KeyName => WebHookConstants.ReceiverKeyName;
+
+        [Fact]
+        public void Accept_Succeeds_WithConstantValue()
+        {
+            // Arrange
+            var webHookEventMetadata = GetEventMetadata();
+            webHookEventMetadata
+                .SetupGet(m => m.ConstantValue)
+                .Returns("constant value");
+
+            var constraint = new WebHookEventMapperConstraint(
+                new[] { webHookEventMetadata.Object },
+                NullLoggerFactory.Instance);
+            var context = GetContext(constraint);
+            context.RouteContext.RouteData.Values.Add(KeyName, "match");
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert
+            ConfirmRequestValueMatch(context, result, expectedValue: "constant value");
+        }
+
+        [Fact]
+        public void Accept_Fails_OnHeaderNonMatch()
+        {
+            // Arrange
+            var webHookEventMetadata = GetEventMetadata();
+            webHookEventMetadata
+                .SetupGet(m => m.HeaderName)
+                .Returns("another");
+
+            var constraint = new WebHookEventMapperConstraint(
+                new[] { webHookEventMetadata.Object },
+                NullLoggerFactory.Instance);
+            var context = GetContext(constraint);
+            context.RouteContext.RouteData.Values.Add(KeyName, "match");
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert (one of the few cases where constraint returns false)
+            Assert.False(result);
+            Assert.DoesNotContain(WebHookConstants.EventKeyName, context.RouteContext.RouteData.Values.Keys);
+        }
+
+        [Fact]
+        public void Accept_Succeeds_OnQueryStringMatch()
+        {
+            // Arrange
+            var webHookEventMetadata = GetEventMetadata();
+            webHookEventMetadata
+                .SetupGet(m => m.ConstantValue)
+                .Returns("constant value");
+            webHookEventMetadata
+                .SetupGet(m => m.QueryParameterName)
+                .Returns("query");
+
+            var constraint = new WebHookEventMapperConstraint(
+                new[] { webHookEventMetadata.Object },
+                NullLoggerFactory.Instance);
+            var context = GetContext(constraint);
+            context.RouteContext.RouteData.Values.Add(KeyName, "match");
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert
+            // Query string match has precedence over constant value.
+            ConfirmRequestValueMatch(context, result, expectedValue: "query string value");
+        }
+
+        [Fact]
+        public void Accept_Fails_OnQueryStringNonMatch()
+        {
+            // Arrange
+            var webHookEventMetadata = GetEventMetadata();
+            webHookEventMetadata
+                .SetupGet(m => m.QueryParameterName)
+                .Returns("another");
+
+            var constraint = new WebHookEventMapperConstraint(
+                new[] { webHookEventMetadata.Object },
+                NullLoggerFactory.Instance);
+            var context = GetContext(constraint);
+            context.RouteContext.RouteData.Values.Add(KeyName, "match");
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert (one of the few cases where constraint returns false)
+            Assert.False(result);
+            Assert.DoesNotContain(WebHookConstants.EventKeyName, context.RouteContext.RouteData.Values.Keys);
+        }
+
+        protected override void ConfirmRequestValueMatch(ActionConstraintContext context, bool result)
+        {
+            // Header match has precedence over query string and constant value.
+            ConfirmRequestValueMatch(context, result, expectedValue: "header value");
+        }
+
+        private void ConfirmRequestValueMatch(ActionConstraintContext context, bool result, string expectedValue)
+        {
+            base.ConfirmRequestValueMatch(context, result);
+
+            var routeValuKvp = Assert.Single(context.RouteContext.RouteData.Values, kvp => string.Equals(
+                WebHookConstants.EventKeyName,
+                kvp.Key,
+                StringComparison.OrdinalIgnoreCase));
+            var routeValue = Assert.IsType<string>(routeValuKvp.Value);
+
+            Assert.Equal(expectedValue, routeValue);
+        }
+
+        protected override void ConfirmRequestValueNonMatch(ActionConstraintContext context, bool result)
+        {
+            // This constraint returns true when no IWebHookEventMetadata exists for the receiver.
+            Assert.True(result);
+
+            Assert.DoesNotContain(WebHookConstants.EventKeyName, context.RouteContext.RouteData.Values.Keys);
+        }
+
+        protected override void ConfirmRequestValueNonMatch(
+            ActionConstraintContext context,
+            Func<ActionConstraintContext, bool> process)
+        {
+            // This constraint throws if request does not contain receiver name route value.
+            // Arrange 2
+            var expectedMessage = "Invalid WebHook constraint configuration encountered. Request contained no " +
+                $"receiver name and '{typeof(WebHookReceiverExistsConstraint)}' should have disallowed the request.";
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(() => process(context));
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        protected override ActionConstraintContext GetContext(IActionConstraint constraint)
+        {
+            var context = base.GetContext(constraint);
+            var request = context.RouteContext.HttpContext.Request;
+            request.Headers.Add("header", "header value");
+            request.QueryString = request.QueryString.Add("query", "query string value");
+
+            return context;
+        }
+
+        protected override IActionConstraint GetConstraint()
+        {
+            var webHookEventMetadata = GetEventMetadata();
+            webHookEventMetadata
+                .SetupGet(m => m.ConstantValue)
+                .Returns("constant value");
+            webHookEventMetadata
+                .SetupGet(m => m.HeaderName)
+                .Returns("header");
+            webHookEventMetadata
+                .SetupGet(m => m.QueryParameterName)
+                .Returns("query");
+
+            return new WebHookEventMapperConstraint(new[] { webHookEventMetadata.Object }, NullLoggerFactory.Instance);
+        }
+
+        private Mock<IWebHookEventMetadata> GetEventMetadata()
+        {
+            var webHookEventMetadata = new Mock<IWebHookEventMetadata>(MockBehavior.Strict);
+            webHookEventMetadata
+                .SetupGet(m => m.ReceiverName)
+                .Returns("match");
+            webHookEventMetadata
+                .Setup(m => m.IsApplicable(It.IsAny<string>()))
+                .Returns((string value) => string.Equals("match", value, StringComparison.OrdinalIgnoreCase));
+
+            // Callers all override at least one property setup.
+            webHookEventMetadata
+                .SetupGet(m => m.ConstantValue)
+                .Returns((string)null);
+            webHookEventMetadata
+                .SetupGet(m => m.HeaderName)
+                .Returns((string)null);
+            webHookEventMetadata
+                .SetupGet(m => m.QueryParameterName)
+                .Returns((string)null);
+
+            return webHookEventMetadata;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.WebHooks.Receivers.Test/Routing/WebHookEventNamesConstraintTestBase.cs
+++ b/test/Microsoft.AspNetCore.WebHooks.Receivers.Test/Routing/WebHookEventNamesConstraintTestBase.cs
@@ -1,0 +1,245 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+using Microsoft.AspNetCore.Routing;
+using Xunit;
+
+namespace Microsoft.AspNetCore.WebHooks.Routing
+{
+    // Variant of WebHookConstraintTestBase which eliminates most tests using ActionDescriptor.RouteValues.
+    public abstract class WebHookEventNamesConstraintTestBase
+    {
+        [Fact]
+        public void Accept_Fails_OnEmpty()
+        {
+            // Arrange
+            var constraint = GetConstraint();
+            var context = GetContext(constraint);
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(WebHookConstraintTestBase.MatchingDataSet), MemberType = typeof(WebHookConstraintTestBase))]
+        public void Accept_Succeeds_OnRouteContextMatch(string requestValue)
+        {
+            // Arrange
+            var constraint = GetConstraint();
+            var context = GetContext(constraint);
+            context.RouteContext.RouteData.Values.Add(WebHookConstants.EventKeyName, requestValue);
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Accept_Succeeds_OnRouteContextMatch_WithMultipleNames()
+        {
+            // Arrange
+            var constraint = GetConstraint();
+            var context = GetContext(constraint);
+            context.RouteContext.RouteData.Values.Add($"{WebHookConstants.EventKeyName}[0]", "another1");
+            context.RouteContext.RouteData.Values.Add($"{WebHookConstants.EventKeyName}[1]", "nonMatch");
+            context.RouteContext.RouteData.Values.Add($"{WebHookConstants.EventKeyName}[2]", "match");
+            context.RouteContext.RouteData.Values.Add($"{WebHookConstants.EventKeyName}[3]", "another2");
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(WebHookConstraintTestBase.NonMatchingDataSet), MemberType = typeof(WebHookConstraintTestBase))]
+        public void Accept_Fails_OnRouteContextNonMatch(string requestValue)
+        {
+            // Arrange
+            var constraint = GetConstraint();
+            var context = GetContext(constraint);
+            context.RouteContext.RouteData.Values.Add(WebHookConstants.EventKeyName, requestValue);
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(WebHookConstraintTestBase.NoRequestValueDataSet), MemberType = typeof(WebHookConstraintTestBase))]
+        public void Accept_Fails_OnNoRouteContextRequestValue(string requestValue)
+        {
+            // Arrange
+            var constraint = GetConstraint();
+            var context = GetContext(constraint);
+            context.RouteContext.RouteData.Values.Add(WebHookConstants.EventKeyName, requestValue);
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        // Constraint does not check ActionDescriptor for event names.
+        [Fact]
+        public void Accept_Fails_OnActionDescriptorMatch()
+        {
+            // Arrange
+            var constraint = GetConstraintForPingMatch();
+            var context = GetContext(constraint);
+            context.CurrentCandidate.Action.RouteValues.Add(WebHookConstants.EventKeyName, "match");
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        // Constraint does not check ActionDescriptor for event names.
+        [Fact]
+        public void Accept_Fails_OnActionDescriptorPingMatch()
+        {
+            // Arrange
+            var constraint = GetConstraintForPingMatch();
+            var context = GetContext(constraint);
+            context.CurrentCandidate.Action.RouteValues.Add(WebHookConstants.EventKeyName, "pingMatch");
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Accept_Succeeds_OnRouteContextPingMatch()
+        {
+            // Arrange
+            var constraint = GetConstraintForPingMatch();
+            var context = GetContext(constraint);
+            context.RouteContext.RouteData.Values.Add(WebHookConstants.EventKeyName, "pingMatch");
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Accept_Succeeds_OnRouteContextPingMatch_WithMultipleNames()
+        {
+            // Arrange
+            var constraint = GetConstraintForPingMatch();
+            var context = GetContext(constraint);
+            context.RouteContext.RouteData.Values.Add($"{WebHookConstants.EventKeyName}[0]", "another1");
+            context.RouteContext.RouteData.Values.Add($"{WebHookConstants.EventKeyName}[1]", "nonMatch");
+            context.RouteContext.RouteData.Values.Add($"{WebHookConstants.EventKeyName}[2]", "pingMatch");
+            context.RouteContext.RouteData.Values.Add($"{WebHookConstants.EventKeyName}[3]", "another2");
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Accept_Fails_OnRouteContextPingMatch_IfSecond()
+        {
+            // Arrange
+            var constraint = GetConstraintForPingMatch();
+
+            // E.g. the other action is configured for a different event using the same receiver-specific attribute.
+            var firstConstraint = GetConstraintForPingMatch();
+
+            var context = GetContext(constraint);
+            context.Candidates = new[]
+            {
+                new ActionSelectorCandidate(new ActionDescriptor(), new[] { firstConstraint }),
+                context.CurrentCandidate,
+            };
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Accept_Fails_OnRouteContextPingMatch_IfLaterActionLacksConstraint()
+        {
+            // Arrange
+            var constraint = GetConstraintForPingMatch();
+            var context = GetContext(constraint);
+            context.CurrentCandidate.Action.RouteValues.Add(WebHookConstants.EventKeyName, "pingMatch");
+            context.Candidates = new[]
+            {
+                context.CurrentCandidate,
+                new ActionSelectorCandidate(new ActionDescriptor(), Array.Empty<IActionConstraint>()),
+            };
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Accept_Fails_OnRouteContextPingMatch_IfLaterActionWillMatch()
+        {
+            // Arrange
+            var constraint = GetConstraintForPingMatch();
+
+            // E.g. the other action is configured specifically for ping requests.
+            var secondConstraint = new WebHookSingleEventNamesConstraint("pingMatch", pingEventName: "pingMatch");
+
+            var context = GetContext(constraint);
+            context.CurrentCandidate.Action.RouteValues.Add(WebHookConstants.EventKeyName, "pingMatch");
+            context.Candidates = new[]
+            {
+                context.CurrentCandidate,
+                new ActionSelectorCandidate(new ActionDescriptor(), new[] { secondConstraint }),
+            };
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        protected abstract IActionConstraint GetConstraint();
+
+        protected abstract IActionConstraint GetConstraintForPingMatch();
+
+        protected virtual ActionConstraintContext GetContext(IActionConstraint constraint)
+        {
+            var candidate = new ActionSelectorCandidate(new ActionDescriptor(), new[] { constraint });
+            var context = new ActionConstraintContext
+            {
+                Candidates = new[] { candidate },
+                CurrentCandidate = candidate,
+                RouteContext = new RouteContext(new DefaultHttpContext()),
+            };
+
+            return context;
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.WebHooks.Receivers.Test/Routing/WebHookIdConstraintTests.cs
+++ b/test/Microsoft.AspNetCore.WebHooks.Receivers.Test/Routing/WebHookIdConstraintTests.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+
+namespace Microsoft.AspNetCore.WebHooks.Routing
+{
+    public class WebHookIdConstraintTests : WebHookConstraintTestBase
+    {
+        protected override string KeyName => WebHookConstants.IdKeyName;
+
+        protected override IActionConstraint GetConstraint()
+        {
+            return new WebHookIdConstraint("match");
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.WebHooks.Receivers.Test/Routing/WebHookMultipleEventNamesConstraintTests.cs
+++ b/test/Microsoft.AspNetCore.WebHooks.Receivers.Test/Routing/WebHookMultipleEventNamesConstraintTests.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+using Microsoft.AspNetCore.WebHooks.Metadata;
+using Moq;
+
+namespace Microsoft.AspNetCore.WebHooks.Routing
+{
+    public class WebHookMultipleEventNamesConstraintTests : WebHookEventNamesConstraintTestBase
+    {
+        protected override ActionConstraintContext GetContext(IActionConstraint constraint)
+        {
+            var context = base.GetContext(constraint);
+
+            // Constraint throws if receiver name is not present in the request.
+            context.RouteContext.RouteData.Values.Add(WebHookConstants.ReceiverKeyName, "ping");
+
+            return context;
+        }
+
+        protected override IActionConstraint GetConstraint()
+        {
+            return new WebHookMultipleEventNamesConstraint("match", Array.Empty<IWebHookPingRequestMetadata>());
+        }
+
+        protected override IActionConstraint GetConstraintForPingMatch()
+        {
+            var pingMetadata = new Mock<IWebHookPingRequestMetadata>(MockBehavior.Strict);
+            pingMetadata
+                .SetupGet(m => m.PingEventName)
+                .Returns("pingMatch");
+            pingMetadata
+                .SetupGet(m => m.ReceiverName)
+                .Returns("ping");
+            pingMetadata
+                .Setup(m => m.IsApplicable(It.IsAny<string>()))
+                .Returns((string value) => string.Equals("ping", value, StringComparison.OrdinalIgnoreCase));
+
+            return new WebHookMultipleEventNamesConstraint("match", new[] { pingMetadata.Object });
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.WebHooks.Receivers.Test/Routing/WebHookReceiverExistsConstraintTests.cs
+++ b/test/Microsoft.AspNetCore.WebHooks.Receivers.Test/Routing/WebHookReceiverExistsConstraintTests.cs
@@ -1,0 +1,64 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+using Microsoft.AspNetCore.WebHooks.Metadata;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.WebHooks.Routing
+{
+    public class WebHookReceiverExistsConstraintTests : WebHookConstraintTestBase
+    {
+        protected override string KeyName => WebHookConstants.ReceiverKeyName;
+
+        [Theory]
+        [MemberData(nameof(MatchingDataSet))]
+        public void Accept_Fails_OnEmptyMetadata(string requestValue)
+        {
+            // Accept
+            var constraint = new WebHookReceiverExistsConstraint(Array.Empty<IWebHookBodyTypeMetadataService>());
+            var context = GetContext(constraint);
+            context.CurrentCandidate.Action.RouteValues.Add(KeyName, requestValue);
+
+            // Act
+            var result = constraint.Accept(context);
+
+            // Assert
+            ConfirmRequestValueNonMatch(context, result);
+        }
+
+        protected override void ConfirmRequestValueMatch(ActionConstraintContext context, bool result)
+        {
+            base.ConfirmRequestValueMatch(context, result);
+
+            var routeValuKvp = Assert.Single(context.RouteContext.RouteData.Values, kvp => string.Equals(
+                WebHookConstants.ReceiverExistsKeyName,
+                kvp.Key,
+                StringComparison.OrdinalIgnoreCase));
+            var routeValue = Assert.IsType<bool>(routeValuKvp.Value);
+            Assert.True(routeValue);
+        }
+
+        protected override void ConfirmRequestValueNonMatch(ActionConstraintContext context, bool result)
+        {
+            base.ConfirmRequestValueNonMatch(context, result);
+
+            Assert.DoesNotContain(WebHookConstants.ReceiverExistsKeyName, context.RouteContext.RouteData.Values.Keys);
+        }
+
+        protected override IActionConstraint GetConstraint()
+        {
+            var webHookBodyTypeMetadataService = new Mock<IWebHookBodyTypeMetadataService>(MockBehavior.Strict);
+            webHookBodyTypeMetadataService
+                .SetupGet(m => m.ReceiverName)
+                .Returns("match");
+            webHookBodyTypeMetadataService
+                .Setup(m => m.IsApplicable(It.IsAny<string>()))
+                .Returns((string value) => string.Equals("match", value, StringComparison.OrdinalIgnoreCase));
+
+            return new WebHookReceiverExistsConstraint(new[] { webHookBodyTypeMetadataService.Object });
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.WebHooks.Receivers.Test/Routing/WebHookReceiverNameConstraintTests.cs
+++ b/test/Microsoft.AspNetCore.WebHooks.Receivers.Test/Routing/WebHookReceiverNameConstraintTests.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+
+namespace Microsoft.AspNetCore.WebHooks.Routing
+{
+    public class WebHookReceiverNameConstraintTests : WebHookConstraintTestBase
+    {
+        protected override string KeyName => WebHookConstants.ReceiverKeyName;
+
+        protected override IActionConstraint GetConstraint()
+        {
+            return new WebHookReceiverNameConstraint("match");
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.WebHooks.Receivers.Test/Routing/WebHookSingleEventNamesConstraintTests.cs
+++ b/test/Microsoft.AspNetCore.WebHooks.Receivers.Test/Routing/WebHookSingleEventNamesConstraintTests.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+
+namespace Microsoft.AspNetCore.WebHooks.Routing
+{
+    public class WebHookSingleEventNamesConstraintTests : WebHookEventNamesConstraintTestBase
+    {
+        protected override IActionConstraint GetConstraint()
+        {
+            return new WebHookSingleEventNamesConstraint("match", pingEventName: null);
+        }
+
+        protected override IActionConstraint GetConstraintForPingMatch()
+        {
+            return new WebHookSingleEventNamesConstraint("match", "pingMatch");
+        }
+    }
+}


### PR DESCRIPTION
- #250
- add `WebHookRouteDataActionDescriptorExtensions` supporting these lookups
- add a bunch o' constraint tests (part of #180)

nit: leave `out` parameters `null` when `WebHookRouteDataExtensions` methods return `false`