### PR TITLE
`throw` if a WebHook action has constraints or is attribute-routed

### DIFF
--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Properties/Resources.Designer.cs
@@ -160,16 +160,7 @@ namespace Microsoft.AspNetCore.WebHooks.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; and &apos;{1}&apos; were applied to the same action. &apos;{2}&apos; must not be combined with another attribute that provides a route template..
-        /// </summary>
-        internal static string RoutingProvider_MixedRouteWithWebHookAttribute {
-            get {
-                return ResourceManager.GetString("RoutingProvider_MixedRouteWithWebHookAttribute", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Could not find a valid configuration for the &apos;{0}&apos; WebHook receiver, instance &apos;{1}&apos;. The value must be at least {2} characters long..
+        ///   Looks up a localized string similar to Could not find a valid configuration for the &apos;{0}&apos; WebHook receiver, instance &apos;{1}&apos;. The value must be between {2} and {3} characters long..
         /// </summary>
         internal static string Security_BadSecret {
             get {
@@ -192,6 +183,15 @@ namespace Microsoft.AspNetCore.WebHooks.Properties {
         internal static string Security_NoSecrets {
             get {
                 return ResourceManager.GetString("Security_NoSecrets", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; and &apos;{1}&apos; were applied to the same action. &apos;{2}&apos; must not be combined with attribute routing or non-WebHook constraints..
+        /// </summary>
+        internal static string SelectorModelProvider_MixedRouteWithWebHookAttribute {
+            get {
+                return ResourceManager.GetString("SelectorModelProvider_MixedRouteWithWebHookAttribute", resourceCulture);
             }
         }
         

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Properties/Resources.resx
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Properties/Resources.resx
@@ -150,9 +150,6 @@
   <data name="RequestReader_ModelBindingFailed" xml:space="preserve">
     <value>The MVC model binding system failed. Model state is valid but model was not set.</value>
   </data>
-  <data name="RoutingProvider_MixedRouteWithWebHookAttribute" xml:space="preserve">
-    <value>'{0}' and '{1}' were applied to the same action. '{2}' must not be combined with another attribute that provides a route template.</value>
-  </data>
   <data name="Security_BadSecret" xml:space="preserve">
     <value>Could not find a valid configuration for the '{0}' WebHook receiver, instance '{1}'. The value must be at least {2} characters long.</value>
   </data>
@@ -161,6 +158,9 @@
   </data>
   <data name="Security_NoSecrets" xml:space="preserve">
     <value>Could not find a valid configuration for the '{0}' WebHook receiver. Configure secret keys for this receiver.</value>
+  </data>
+  <data name="SelectorModelProvider_MixedRouteWithWebHookAttribute" xml:space="preserve">
+    <value>'{0}' and '{1}' were applied to the same action. '{2}' must not be combined with attribute routing or non-WebHook constraints.</value>
   </data>
   <data name="VerifyBody_NoFormData" xml:space="preserve">
     <value>The '{0}' WebHook receiver does not support content type '{1}'. The WebHook request must contain an entity body formatted as HTML form URL-encoded data.</value>


### PR DESCRIPTION
- #248
- do not detect `[ApiController]` itself
  - `ApiBehaviorApplicationModelProvider` throws if that attribute used on non-attribute-routed actions

nits:
- update `WebHookSelectorModelProvider` methods to match constraints added
- correct name of resource used in `WebHookSelectorModelProvider` to match class