### PR TITLE
Merge to `dev`: Fix gaps in final commit for #258 (c9ab0b4ede)

### DIFF
--- a/WebHooks.sln
+++ b/WebHooks.sln
@@ -94,6 +94,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.WebHoo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TrelloCoreReceiver", "samples\TrelloCoreReceiver\TrelloCoreReceiver.csproj", "{E9E37253-3FE1-44A4-A9E7-A2B6C54EECFE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.WebHooks.FunctionalTest", "test\Microsoft.AspNetCore.WebHooks.FunctionalTest\Microsoft.AspNetCore.WebHooks.FunctionalTest.csproj", "{F42E56B7-60D4-481A-8585-04015B2B501E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -232,6 +234,10 @@ Global
 		{E9E37253-3FE1-44A4-A9E7-A2B6C54EECFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E9E37253-3FE1-44A4-A9E7-A2B6C54EECFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E9E37253-3FE1-44A4-A9E7-A2B6C54EECFE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F42E56B7-60D4-481A-8585-04015B2B501E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F42E56B7-60D4-481A-8585-04015B2B501E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F42E56B7-60D4-481A-8585-04015B2B501E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F42E56B7-60D4-481A-8585-04015B2B501E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -270,9 +276,10 @@ Global
 		{3EE810BD-AE8A-43F8-AC80-F490C0E2B3D8} = {9575CB90-BC4B-43BB-8AEA-82C53FDA4187}
 		{91E02D64-BA6E-473C-A250-D1051A50DDAB} = {9575CB90-BC4B-43BB-8AEA-82C53FDA4187}
 		{E9E37253-3FE1-44A4-A9E7-A2B6C54EECFE} = {E957C8D9-B4A0-488B-838F-BAB4DE080A76}
+		{F42E56B7-60D4-481A-8585-04015B2B501E} = {9575CB90-BC4B-43BB-8AEA-82C53FDA4187}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		EnterpriseLibraryConfigurationToolBinariesPathV6 = packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8;packages\EnterpriseLibrary.TransientFaultHandling.Data.6.0.1304.1\lib\NET45
 		SolutionGuid = {12CE6238-F847-4984-8622-1ED46072150A}
+		EnterpriseLibraryConfigurationToolBinariesPathV6 = packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8;packages\EnterpriseLibrary.TransientFaultHandling.Data.6.0.1304.1\lib\NET45
 	EndGlobalSection
 EndGlobal

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
@@ -8,6 +8,7 @@
     <MicrosoftAspNetCoreMvcCorePackageVersion>2.1.0-preview3-32233</MicrosoftAspNetCoreMvcCorePackageVersion>
     <MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>2.1.0-preview3-32233</MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>
     <MicrosoftAspNetCoreMvcFormattersXmlPackageVersion>2.1.0-preview3-32233</MicrosoftAspNetCoreMvcFormattersXmlPackageVersion>
+    <MicrosoftAspNetCoreMvcTestingPackageVersion>2.1.0-preview3-32233</MicrosoftAspNetCoreMvcTestingPackageVersion>
     <MicrosoftAspNetCorePackageVersion>2.1.0-preview3-32233</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreStaticFilesPackageVersion>2.1.0-preview3-32233</MicrosoftAspNetCoreStaticFilesPackageVersion>
     <MicrosoftAspNetCoreTestingPackageVersion>2.1.0-preview3-32233</MicrosoftAspNetCoreTestingPackageVersion>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -3,5 +3,10 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+
+    <DeveloperBuildTestWebsiteTfms Condition=" '$(DeveloperBuildTestWebsiteTfms)' == '' ">netcoreapp2.1</DeveloperBuildTestWebsiteTfms>
+    <StandardTestWebsiteTfms>$(DeveloperBuildTestWebsiteTfms)</StandardTestWebsiteTfms>
+    <StandardTestWebsiteTfms Condition=" '$(DeveloperBuild)' != 'true' ">netcoreapp2.1</StandardTestWebsiteTfms>
+    <StandardTestWebsiteTfms Condition=" '$(DeveloperBuild)' != 'true' AND '$(OS)' == 'Windows_NT' ">$(StandardTestWebsiteTfms);net461</StandardTestWebsiteTfms>
   </PropertyGroup>
 </Project>

--- a/samples/DropboxCoreReceiver/DropboxCoreReceiver.csproj
+++ b/samples/DropboxCoreReceiver/DropboxCoreReceiver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>$(StandardTestWebsiteTfms)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/DropboxCoreReceiver/Program.cs
+++ b/samples/DropboxCoreReceiver/Program.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore;
+using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 
 namespace DropboxCoreReceiver
@@ -7,12 +7,11 @@ namespace DropboxCoreReceiver
     {
         public static void Main(string[] args)
         {
-            BuildWebHost(args).Run();
+            CreateWebHostBuilder(args).Build().Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
-                .Build();
+                .UseStartup<Startup>();
     }
 }

--- a/samples/DropboxCoreReceiver/appsettings.json
+++ b/samples/DropboxCoreReceiver/appsettings.json
@@ -1,0 +1,3 @@
+{
+  "WebHooks:Dropbox:SecretKey:default": "012345678901234"
+}

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/ApplicationModels/WebHookActionModelPropertyProvider.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/ApplicationModels/WebHookActionModelPropertyProvider.cs
@@ -380,7 +380,7 @@ namespace Microsoft.AspNetCore.WebHooks.ApplicationModels
             {
                 var message = string.Format(
                     CultureInfo.CurrentCulture,
-                    Resources.MetadataProvider_MissingMetadata,
+                    Resources.PropertyProvider_MissingMetadata,
                     receiverName,
                     typeof(IWebHookBodyTypeMetadataService));
                 throw new InvalidOperationException(message);
@@ -410,7 +410,7 @@ namespace Microsoft.AspNetCore.WebHooks.ApplicationModels
                 // IWebHookEventMetadata is mandatory when performing action selection using event names.
                 var message = string.Format(
                     CultureInfo.CurrentCulture,
-                    Resources.MetadataProvider_MissingMetadataServices,
+                    Resources.PropertyProvider_MissingMetadataServices,
                     receiverName,
                     typeof(IWebHookEventSelectorMetadata),
                     typeof(IWebHookEventMetadata));
@@ -449,7 +449,7 @@ namespace Microsoft.AspNetCore.WebHooks.ApplicationModels
             {
                 var message = string.Format(
                     CultureInfo.CurrentCulture,
-                    Resources.MetadataProvider_ConflictingMetadataServices,
+                    Resources.PropertyProvider_ConflictingMetadataServices,
                     receiverWithConflictingMetadata.ReceiverName,
                     typeof(IWebHookEventFromBodyMetadata),
                     typeof(IWebHookEventMetadata));
@@ -484,7 +484,7 @@ namespace Microsoft.AspNetCore.WebHooks.ApplicationModels
             {
                 var message = string.Format(
                     CultureInfo.CurrentCulture,
-                    Resources.MetadataProvider_DuplicateMetadata,
+                    Resources.PropertyProvider_DuplicateMetadata,
                     duplicateMetadataGroup.Key, // ReceiverName
                     typeof(TService));
                 throw new InvalidOperationException(message);

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Extensions/WebHookServiceCollectionSetup.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Extensions/WebHookServiceCollectionSetup.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.WebHooks;
 using Microsoft.AspNetCore.WebHooks.ApplicationModels;
 using Microsoft.AspNetCore.WebHooks.Filters;
+using Microsoft.AspNetCore.WebHooks.Metadata;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -26,6 +27,8 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 throw new ArgumentNullException(nameof(services));
             }
+
+            services.TryAddSingleton<WebHookMetadataProvider, DefaultWebHookMetadataProvider>();
 
             services.TryAddEnumerable(
                 ServiceDescriptor.Transient<IApplicationModelProvider, WebHookActionModelFilterProvider>());

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Metadata/WebHookMetadata.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Metadata/WebHookMetadata.cs
@@ -76,6 +76,11 @@ namespace Microsoft.AspNetCore.WebHooks.Metadata
                 services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IWebHookEventMetadata), type));
             }
 
+            if (typeof(IWebHookFilterMetadata).IsAssignableFrom(type))
+            {
+                services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IWebHookFilterMetadata), type));
+            }
+
             if (typeof(IWebHookGetHeadRequestMetadata).IsAssignableFrom(type))
             {
                 services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IWebHookGetHeadRequestMetadata), type));

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Properties/Resources.Designer.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Properties/Resources.Designer.cs
@@ -117,36 +117,36 @@ namespace Microsoft.AspNetCore.WebHooks.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Invalid metadata services found for the &apos;{0}&apos; WebHook receiver. Receivers must not provide both &apos;{1}&apos; and &apos;{2}&apos; services..
         /// </summary>
-        internal static string MetadataProvider_ConflictingMetadataServices {
+        internal static string PropertyProvider_ConflictingMetadataServices {
             get {
-                return ResourceManager.GetString("MetadataProvider_ConflictingMetadataServices", resourceCulture);
+                return ResourceManager.GetString("PropertyProvider_ConflictingMetadataServices", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Invalid metadata services found for the &apos;{0}&apos; WebHook receiver. Receivers must not have more than one &apos;{1}&apos; registration..
         /// </summary>
-        internal static string MetadataProvider_DuplicateMetadata {
+        internal static string PropertyProvider_DuplicateMetadata {
             get {
-                return ResourceManager.GetString("MetadataProvider_DuplicateMetadata", resourceCulture);
+                return ResourceManager.GetString("PropertyProvider_DuplicateMetadata", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Invalid metadata services found for the &apos;{0}&apos; WebHook receiver. Receiver must have an &apos;{1}&apos; implementation..
         /// </summary>
-        internal static string MetadataProvider_MissingMetadata {
+        internal static string PropertyProvider_MissingMetadata {
             get {
-                return ResourceManager.GetString("MetadataProvider_MissingMetadata", resourceCulture);
+                return ResourceManager.GetString("PropertyProvider_MissingMetadata", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Invalid metadata services found for the &apos;{0}&apos; WebHook receiver. Receivers with attributes implementing &apos;{1}&apos; must also provide a &apos;{2}&apos; service..
         /// </summary>
-        internal static string MetadataProvider_MissingMetadataServices {
+        internal static string PropertyProvider_MissingMetadataServices {
             get {
-                return ResourceManager.GetString("MetadataProvider_MissingMetadataServices", resourceCulture);
+                return ResourceManager.GetString("PropertyProvider_MissingMetadataServices", resourceCulture);
             }
         }
         
@@ -228,6 +228,15 @@ namespace Microsoft.AspNetCore.WebHooks.Properties {
         internal static string VerifyCode_BadCode {
             get {
                 return ResourceManager.GetString("VerifyCode_BadCode", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The &apos;{0}&apos; WebHook receiver does not support an empty request body..
+        /// </summary>
+        internal static string VerifyMethod_BadBody {
+            get {
+                return ResourceManager.GetString("VerifyMethod_BadBody", resourceCulture);
             }
         }
         

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Properties/Resources.resx
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Properties/Resources.resx
@@ -135,16 +135,16 @@
   <data name="GetRequest_NoQueryParameter" xml:space="preserve">
     <value>A '{0}' WebHook verification request must contain a '{1}' query parameter.</value>
   </data>
-  <data name="MetadataProvider_ConflictingMetadataServices" xml:space="preserve">
+  <data name="PropertyProvider_ConflictingMetadataServices" xml:space="preserve">
     <value>Invalid metadata services found for the '{0}' WebHook receiver. Receivers must not provide both '{1}' and '{2}' services.</value>
   </data>
-  <data name="MetadataProvider_DuplicateMetadata" xml:space="preserve">
+  <data name="PropertyProvider_DuplicateMetadata" xml:space="preserve">
     <value>Invalid metadata services found for the '{0}' WebHook receiver. Receivers must not have more than one '{1}' registration.</value>
   </data>
-  <data name="MetadataProvider_MissingMetadata" xml:space="preserve">
+  <data name="PropertyProvider_MissingMetadata" xml:space="preserve">
     <value>Invalid metadata services found for the '{0}' WebHook receiver. Receiver must have an '{1}' implementation.</value>
   </data>
-  <data name="MetadataProvider_MissingMetadataServices" xml:space="preserve">
+  <data name="PropertyProvider_MissingMetadataServices" xml:space="preserve">
     <value>Invalid metadata services found for the '{0}' WebHook receiver. Receivers with attributes implementing '{1}' must also provide a '{2}' service.</value>
   </data>
   <data name="RequestReader_ModelBindingFailed" xml:space="preserve">
@@ -173,6 +173,9 @@
   </data>
   <data name="VerifyCode_BadCode" xml:space="preserve">
     <value>The '{0}' query parameter provided in the HTTP request did not match the expected value.</value>
+  </data>
+  <data name="VerifyMethod_BadBody" xml:space="preserve">
+    <value>The '{0}' WebHook receiver does not support an empty request body.</value>
   </data>
   <data name="VerifyMethod_BadMethod" xml:space="preserve">
     <value>The '{0}' WebHook receiver does not support the HTTP '{1}' method.</value>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <DeveloperBuildTestTfms Condition=" '$(DeveloperBuildTestTfms)' == '' ">netcoreapp2.1</DeveloperBuildTestTfms>
     <StandardTestTfms>$(DeveloperBuildTestTfms)</StandardTestTfms>
-    <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' ">netcoreapp2.1;netcoreapp2.0</StandardTestTfms>
+    <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' ">netcoreapp2.1</StandardTestTfms>
     <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'true' AND '$(OS)' == 'Windows_NT' ">$(StandardTestTfms);net461</StandardTestTfms>
   </PropertyGroup>
 

--- a/test/Microsoft.AspNetCore.WebHooks.FunctionalTest/DropboxSampleTest.cs
+++ b/test/Microsoft.AspNetCore.WebHooks.FunctionalTest/DropboxSampleTest.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using DropboxCoreReceiver;
+using Xunit;
+
+namespace Microsoft.AspNetCore.WebHooks.FunctionalTest
+{
+    public class DropboxSampleTest : IClassFixture<WebHookTestFixture<Startup>>
+    {
+        private readonly HttpClient _client;
+
+        public DropboxSampleTest(WebHookTestFixture<Startup> fixture)
+        {
+            _client = fixture.CreateClient();
+        }
+
+        [Fact]
+        public async Task HomePage_IsNotFound()
+        {
+            // Arrange & Act
+            var response = await _client.GetAsync("/");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task WebHookPage_Get_ReturnsChallenge()
+        {
+            // Arrange & Act
+            var response = await _client.GetAsync("/api/webhooks/incoming/dropbox?challenge=012345678901234");
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            var responseText = await response.Content.ReadAsStringAsync();
+            Assert.Equal("012345678901234", responseText);
+        }
+    }
+}

--- a/test/Microsoft.AspNetCore.WebHooks.FunctionalTest/Microsoft.AspNetCore.WebHooks.FunctionalTest.csproj
+++ b/test/Microsoft.AspNetCore.WebHooks.FunctionalTest/Microsoft.AspNetCore.WebHooks.FunctionalTest.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>Microsoft.AspNetCore.WebHooks.FunctionalTest</RootNamespace>
+    <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\samples\DropboxCoreReceiver\DropboxCoreReceiver.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(MicrosoftAspNetCoreMvcTestingPackageVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/test/Microsoft.AspNetCore.WebHooks.FunctionalTest/WebHookTestFixture.cs
+++ b/test/Microsoft.AspNetCore.WebHooks.FunctionalTest/WebHookTestFixture.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.AspNetCore.WebHooks.FunctionalTest
+{
+    public class WebHookTestFixture<TStartup> : WebApplicationFactory<TStartup>
+        where TStartup : class
+    {
+        public WebHookTestFixture()
+            : base()
+        {
+            ClientOptions.BaseAddress = new Uri("https://localhost");
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            base.ConfigureWebHost(builder);
+
+            builder.ConfigureServices(services =>
+            {
+                services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+                services.Configure<MvcCompatibilityOptions>(
+                    options => options.CompatibilityVersion = CompatibilityVersion.Latest);
+            });
+        }
+    }
+}


### PR DESCRIPTION
- #275
- register `DefaultWebHookMetadataProvider` in DI
- register `IWebHookFilterMetadata` implementations in DI
- fix parameter reversal and overuse of `Resources.VerifyMethod_BadMethod`
- add first functional tests
  - part of #180
  - add functional test infrastructure
  - update `DropboxCoreReceiver` to meet new requirements e.g. add test-only secret key

nits:
- correct names of resources
- let VS remove a few UTF8 BOMs