### PR TITLE
Remove ambiguity between general WebHook and receiver-specific actions

### DIFF
--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.MailChimp/Metadata/MailChimpMetadata.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.MailChimp/Metadata/MailChimpMetadata.cs
@@ -39,7 +39,6 @@ namespace Microsoft.AspNetCore.WebHooks.Metadata
         public bool AllowHeadRequests => false;
 
         /// <inheritdoc />
-        /// <inheritdoc />
         public string ChallengeQueryParameterName => null;
 
         /// <inheritdoc />

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/Extensions/SalesforceMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/Extensions/SalesforceMvcBuilderExtensions.cs
@@ -19,10 +19,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// WebHook requests.
         /// </para>
         /// <para>
-        /// The '<c>WebHooks:SalesforceSoap:SecretKey:default</c>' configuration value contains the secret key for
-        /// Salesforce WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/sfsoap</c>'.
-        /// '<c>WebHooks:SalesforceSoap:SecretKey:{id}</c>' configuration values contain secret keys for Salesforce
-        /// WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/sfsoap/{id}</c>'. Secret keys are
+        /// The '<c>WebHooks:Salesforce:SecretKey:default</c>' configuration value contains the secret key for
+        /// Salesforce WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/salesforce</c>'.
+        /// '<c>WebHooks:Salesforce:SecretKey:{id}</c>' configuration values contain secret keys for Salesforce
+        /// WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/salesforce/{id}</c>'. Secret keys are
         /// Salesforce Organization IDs and can be found at <see href="https://www.salesforce.com"/> under
         /// <c>Setup | Company Profile | Company Information</c>.
         /// </para>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/Extensions/SalesforceMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers.Salesforce/Extensions/SalesforceMvcCoreBuilderExtensions.cs
@@ -19,10 +19,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// WebHook requests.
         /// </para>
         /// <para>
-        /// The '<c>WebHooks:SalesforceSoap:SecretKey:default</c>' configuration value contains the secret key for
-        /// Salesforce WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/sfsoap</c>'.
-        /// '<c>WebHooks:SalesforceSoap:SecretKey:{id}</c>' configuration values contain secret keys for Salesforce
-        /// WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/sfsoap/{id}</c>'. Secret keys are
+        /// The '<c>WebHooks:Salesforce:SecretKey:default</c>' configuration value contains the secret key for
+        /// Salesforce WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/salesforce</c>'.
+        /// '<c>WebHooks:Salesforce:SecretKey:{id}</c>' configuration values contain secret keys for Salesforce
+        /// WebHook URIs of the form '<c>https://{host}/api/webhooks/incoming/salesforce/{id}</c>'. Secret keys are
         /// Salesforce Organization IDs and can be found at <see href="https://www.salesforce.com"/> under
         /// <c>Setup | Company Profile | Company Information</c>.
         /// </para>

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookReceiverNameConstraint.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Routing/WebHookReceiverNameConstraint.cs
@@ -17,6 +17,7 @@ namespace Microsoft.AspNetCore.WebHooks.Routing
     {
         private readonly IWebHookBodyTypeMetadataService _bodyTypeMetadata;
         private readonly WebHookMetadataProvider _metadataProvider;
+        private readonly int _order;
 
         /// <summary>
         /// Instantiates a new <see cref="WebHookReceiverNameConstraint"/> instance to verify the request matches the
@@ -26,6 +27,7 @@ namespace Microsoft.AspNetCore.WebHooks.Routing
         public WebHookReceiverNameConstraint(IWebHookBodyTypeMetadataService bodyTypeMetadata)
         {
             _bodyTypeMetadata = bodyTypeMetadata;
+            _order = Order;
         }
 
         /// <summary>
@@ -39,17 +41,24 @@ namespace Microsoft.AspNetCore.WebHooks.Routing
         public WebHookReceiverNameConstraint(WebHookMetadataProvider metadataProvider)
         {
             _metadataProvider = metadataProvider;
+            _order = Order + 5;
         }
 
         /// <summary>
-        /// Gets the <see cref="IActionConstraint.Order"/> value used in all
+        /// Gets the minimum <see cref="IActionConstraint.Order"/> value used in all
         /// <see cref="WebHookReceiverNameConstraint"/> instances.
         /// </summary>
         /// <value>Chosen to run this constraint early in action selection.</value>
+        /// <remarks>
+        /// <see cref="IActionConstraint.Order"/> is <see cref="Order"/> when an instance is instantiated with the
+        /// <see cref="WebHookReceiverNameConstraint(IWebHookBodyTypeMetadataService)"/> constructor.
+        /// <see cref="IActionConstraint.Order"/> is <c>Order + 5</c> when instantiated with the
+        /// <see cref="WebHookReceiverNameConstraint(WebHookMetadataProvider)"/> constructor.
+        /// </remarks>
         public static int Order => -500;
 
         /// <inheritdoc />
-        int IActionConstraint.Order => Order;
+        int IActionConstraint.Order => _order;
 
         /// <inheritdoc />
         public bool Accept(ActionConstraintContext context)


### PR DESCRIPTION
- #291
- increase `IActionConstraint.Order` of `WebHookReceiverNameConstraint` when used for `[GeneralWebHook]` actions
- also correct doc comments to match Salesforce secret key names and URLs
  - follow-up on ff7ed820e7 (the #193 fix)

nits:
- remove extra `<inheritdoc/>`