### PR TITLE
Disable Global Routing in all applications using WebHooks

### DIFF
--- a/WebHooks.sln
+++ b/WebHooks.sln
@@ -98,7 +98,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.WebHoo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TrelloCoreReceiver", "samples\TrelloCoreReceiver\TrelloCoreReceiver.csproj", "{E9E37253-3FE1-44A4-A9E7-A2B6C54EECFE}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.WebHooks.FunctionalTest", "test\Microsoft.AspNetCore.WebHooks.FunctionalTest\Microsoft.AspNetCore.WebHooks.FunctionalTest.csproj", "{F42E56B7-60D4-481A-8585-04015B2B501E}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNetCore.WebHooks.FunctionalTest", "test\Microsoft.AspNetCore.WebHooks.FunctionalTest\Microsoft.AspNetCore.WebHooks.FunctionalTest.csproj", "{F42E56B7-60D4-481A-8585-04015B2B501E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -178,10 +178,6 @@ Global
 		{66B213C4-0647-4E6A-9A1A-98653F60FC74}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{66B213C4-0647-4E6A-9A1A-98653F60FC74}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{66B213C4-0647-4E6A-9A1A-98653F60FC74}.Release|Any CPU.Build.0 = Release|Any CPU
-		{34CE87FF-05A7-4463-9F43-722194FEAACF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{34CE87FF-05A7-4463-9F43-722194FEAACF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{34CE87FF-05A7-4463-9F43-722194FEAACF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{34CE87FF-05A7-4463-9F43-722194FEAACF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FB7E7FF1-4DAC-45D6-8128-1A528CE9A4D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FB7E7FF1-4DAC-45D6-8128-1A528CE9A4D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FB7E7FF1-4DAC-45D6-8128-1A528CE9A4D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -250,6 +246,10 @@ Global
 		{F42E56B7-60D4-481A-8585-04015B2B501E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F42E56B7-60D4-481A-8585-04015B2B501E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F42E56B7-60D4-481A-8585-04015B2B501E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{34CE87FF-05A7-4463-9F43-722194FEAACF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{34CE87FF-05A7-4463-9F43-722194FEAACF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{34CE87FF-05A7-4463-9F43-722194FEAACF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{34CE87FF-05A7-4463-9F43-722194FEAACF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -273,7 +273,6 @@ Global
 		{D337952E-4081-43CB-9C98-BAE6F5D72BAF} = {929F44D0-A040-4DC3-A22F-4C5829C05D44}
 		{903CC30B-952F-4786-BD7B-688C65ACB8D9} = {E957C8D9-B4A0-488B-838F-BAB4DE080A76}
 		{66B213C4-0647-4E6A-9A1A-98653F60FC74} = {E957C8D9-B4A0-488B-838F-BAB4DE080A76}
-		{34CE87FF-05A7-4463-9F43-722194FEAACF} = {E957C8D9-B4A0-488B-838F-BAB4DE080A76}
 		{FB7E7FF1-4DAC-45D6-8128-1A528CE9A4D1} = {E957C8D9-B4A0-488B-838F-BAB4DE080A76}
 		{F60AE9EC-E168-4607-B781-B6A464EEAA79} = {E957C8D9-B4A0-488B-838F-BAB4DE080A76}
 		{EA934BCE-6781-40AA-A0F6-0EDC697594BF} = {E957C8D9-B4A0-488B-838F-BAB4DE080A76}
@@ -291,9 +290,10 @@ Global
 		{91E02D64-BA6E-473C-A250-D1051A50DDAB} = {9575CB90-BC4B-43BB-8AEA-82C53FDA4187}
 		{E9E37253-3FE1-44A4-A9E7-A2B6C54EECFE} = {E957C8D9-B4A0-488B-838F-BAB4DE080A76}
 		{F42E56B7-60D4-481A-8585-04015B2B501E} = {9575CB90-BC4B-43BB-8AEA-82C53FDA4187}
+		{34CE87FF-05A7-4463-9F43-722194FEAACF} = {E957C8D9-B4A0-488B-838F-BAB4DE080A76}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		EnterpriseLibraryConfigurationToolBinariesPathV6 = packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8;packages\EnterpriseLibrary.TransientFaultHandling.Data.6.0.1304.1\lib\NET45
 		SolutionGuid = {12CE6238-F847-4984-8622-1ED46072150A}
+		EnterpriseLibraryConfigurationToolBinariesPathV6 = packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8;packages\EnterpriseLibrary.TransientFaultHandling.Data.6.0.1304.1\lib\NET45
 	EndGlobalSection
 EndGlobal

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -4,18 +4,18 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package Versions">
-    <InternalAspNetCoreSdkPackageVersion>3.0.0-alpha1-10011</InternalAspNetCoreSdkPackageVersion>
-    <MicrosoftAspNetCoreMvcCorePackageVersion>3.0.0-alpha1-10123</MicrosoftAspNetCoreMvcCorePackageVersion>
-    <MicrosoftAspNetCoreMvcDataAnnotationsPackageVersion>3.0.0-alpha1-10123</MicrosoftAspNetCoreMvcDataAnnotationsPackageVersion>
-    <MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>3.0.0-alpha1-10123</MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>
-    <MicrosoftAspNetCoreMvcFormattersXmlPackageVersion>3.0.0-alpha1-10123</MicrosoftAspNetCoreMvcFormattersXmlPackageVersion>
-    <MicrosoftAspNetCoreMvcTestingPackageVersion>3.0.0-alpha1-10123</MicrosoftAspNetCoreMvcTestingPackageVersion>
-    <MicrosoftAspNetCorePackageVersion>3.0.0-alpha1-10123</MicrosoftAspNetCorePackageVersion>
-    <MicrosoftAspNetCoreStaticFilesPackageVersion>3.0.0-alpha1-10123</MicrosoftAspNetCoreStaticFilesPackageVersion>
-    <MicrosoftAspNetCoreTestingPackageVersion>3.0.0-alpha1-10123</MicrosoftAspNetCoreTestingPackageVersion>
-    <MicrosoftExtensionsConfigurationPackageVersion>3.0.0-alpha1-10123</MicrosoftExtensionsConfigurationPackageVersion>
-    <MicrosoftExtensionsLoggingTestingPackageVersion>3.0.0-alpha1-10123</MicrosoftExtensionsLoggingTestingPackageVersion>
-    <MicrosoftExtensionsPrimitivesPackageVersion>3.0.0-alpha1-10123</MicrosoftExtensionsPrimitivesPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion>3.0.0-alpha1-10013</InternalAspNetCoreSdkPackageVersion>
+    <MicrosoftAspNetCoreMvcCorePackageVersion>3.0.0-alpha1-10151</MicrosoftAspNetCoreMvcCorePackageVersion>
+    <MicrosoftAspNetCoreMvcDataAnnotationsPackageVersion>3.0.0-alpha1-10151</MicrosoftAspNetCoreMvcDataAnnotationsPackageVersion>
+    <MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>3.0.0-alpha1-10151</MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>
+    <MicrosoftAspNetCoreMvcFormattersXmlPackageVersion>3.0.0-alpha1-10151</MicrosoftAspNetCoreMvcFormattersXmlPackageVersion>
+    <MicrosoftAspNetCoreMvcTestingPackageVersion>3.0.0-alpha1-10151</MicrosoftAspNetCoreMvcTestingPackageVersion>
+    <MicrosoftAspNetCorePackageVersion>3.0.0-alpha1-10151</MicrosoftAspNetCorePackageVersion>
+    <MicrosoftAspNetCoreStaticFilesPackageVersion>3.0.0-alpha1-10151</MicrosoftAspNetCoreStaticFilesPackageVersion>
+    <MicrosoftAspNetCoreTestingPackageVersion>3.0.0-alpha1-10151</MicrosoftAspNetCoreTestingPackageVersion>
+    <MicrosoftExtensionsConfigurationPackageVersion>3.0.0-alpha1-10151</MicrosoftExtensionsConfigurationPackageVersion>
+    <MicrosoftExtensionsLoggingTestingPackageVersion>3.0.0-alpha1-10151</MicrosoftExtensionsLoggingTestingPackageVersion>
+    <MicrosoftExtensionsPrimitivesPackageVersion>3.0.0-alpha1-10151</MicrosoftExtensionsPrimitivesPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>
     <MicrosoftNETCoreApp21PackageVersion>2.1.2</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNETCoreApp22PackageVersion>2.2.0-preview1-26618-02</MicrosoftNETCoreApp22PackageVersion>
@@ -23,9 +23,9 @@
     <MoqPackageVersion>4.7.49</MoqPackageVersion>
     <NETStandardLibrary20PackageVersion>2.0.3</NETStandardLibrary20PackageVersion>
     <NewtonsoftJsonPackageVersion>11.0.2</NewtonsoftJsonPackageVersion>
-    <XunitAnalyzersPackageVersion>0.9.0</XunitAnalyzersPackageVersion>
+    <XunitAnalyzersPackageVersion>0.10.0</XunitAnalyzersPackageVersion>
     <XunitPackageVersion>2.3.1</XunitPackageVersion>
-    <XunitRunnerVisualStudioPackageVersion>2.4.0-rc.1.build4038</XunitRunnerVisualStudioPackageVersion>
+    <XunitRunnerVisualStudioPackageVersion>2.4.0</XunitRunnerVisualStudioPackageVersion>
   </PropertyGroup>
 
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition=" '$(DotNetPackageVersionPropsPath)' != '' " />

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:3.0.0-alpha1-10011
-commithash:717c2eb1f91dafd2580c1a9b8e5064d12dd8c054
+version:3.0.0-alpha1-10013
+commithash:628417048433e285f34f317263aed9e8a5b765a9

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Extensions/WebHookMvcBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Extensions/WebHookMvcBuilderExtensions.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             WebHookServiceCollectionSetup.AddWebHookServices(builder.Services);
+            builder.AddMvcOptions(options => options.EnableGlobalRouting = false);
 
             return builder;
         }

--- a/src/Microsoft.AspNetCore.WebHooks.Receivers/Extensions/WebHookMvcCoreBuilderExtensions.cs
+++ b/src/Microsoft.AspNetCore.WebHooks.Receivers/Extensions/WebHookMvcCoreBuilderExtensions.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             WebHookServiceCollectionSetup.AddWebHookServices(builder.Services);
+            builder.AddMvcOptions(options => options.EnableGlobalRouting = false);
 
             return builder;
         }

--- a/test/Microsoft.AspNetCore.WebHooks.FunctionalTest/AzureContainerRegistryCoreReceiverTest.cs
+++ b/test/Microsoft.AspNetCore.WebHooks.FunctionalTest/AzureContainerRegistryCoreReceiverTest.cs
@@ -5,9 +5,9 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-using AzureContainerRegistryCoreReceiver;
 using Microsoft.Net.Http.Headers;
 using Xunit;
+using AzureContainerRegistryCoreReceiver;
 
 namespace Microsoft.AspNetCore.WebHooks.FunctionalTest
 {
@@ -45,7 +45,7 @@ namespace Microsoft.AspNetCore.WebHooks.FunctionalTest
             }
         }
 
-        [Theory(Skip = "Flaky test aspnet/WebHooks#314; see also aspnet/WebHooks#318.")]
+        [Theory]
         [MemberData(nameof(NonPostDataSet))]
         public async Task WebHookAction_NonPost_IsNotAllowed(HttpMethod method)
         {
@@ -81,7 +81,7 @@ namespace Microsoft.AspNetCore.WebHooks.FunctionalTest
             Assert.Equal(expectedErrorMessage, responseText);
         }
 
-        [Fact(Skip = "Flaky test aspnet/WebHooks#316; see also aspnet/WebHooks#318.")]
+        [Fact]
         public async Task WebHookAction_WrongCode_IsBadRequest()
         {
             // Arrange
@@ -101,7 +101,7 @@ namespace Microsoft.AspNetCore.WebHooks.FunctionalTest
             Assert.Equal(expectedErrorMessage, responseText);
         }
 
-        [Fact(Skip = "Flaky test aspnet/WebHooks#313; see also aspnet/WebHooks#318.")]
+        [Fact]
         public async Task WebHookAction_NoBody_IsBadRequest()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.WebHooks.FunctionalTest/BitbucketStronglyTypedCoreReceiverTest.cs
+++ b/test/Microsoft.AspNetCore.WebHooks.FunctionalTest/BitbucketStronglyTypedCoreReceiverTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.WebHooks.FunctionalTest
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
-        [Fact(Skip = "Flaky test aspnet/WebHooks#315; see also aspnet/WebHooks#318.")]
+        [Fact]
         public async Task WebHookAction_NoEventHeader_IsNotFound()
         {
             // Arrange
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.WebHooks.FunctionalTest
             }
         }
 
-        [Theory(Skip = "Flaky test aspnet/WebHooks#314; see also aspnet/WebHooks#318.")]
+        [Theory]
         [MemberData(nameof(NonPostDataSet))]
         public async Task WebHookAction_NonPost_IsNotAllowed(HttpMethod method)
         {
@@ -119,7 +119,7 @@ namespace Microsoft.AspNetCore.WebHooks.FunctionalTest
             Assert.Equal(expectedErrorMessage, responseText);
         }
 
-        [Fact(Skip = "Flaky test aspnet/WebHooks#316; see also aspnet/WebHooks#318.")]
+        [Fact]
         public async Task WebHookAction_WrongCode_IsBadRequest()
         {
             // Arrange
@@ -147,7 +147,7 @@ namespace Microsoft.AspNetCore.WebHooks.FunctionalTest
             Assert.Equal(expectedErrorMessage, responseText);
         }
 
-        [Fact(Skip = "Flaky test aspnet/WebHooks#317; see also aspnet/WebHooks#318.")]
+        [Fact]
         public async Task WebHookAction_NoUUID_IsBadRequest()
         {
             // Arrange
@@ -175,7 +175,7 @@ namespace Microsoft.AspNetCore.WebHooks.FunctionalTest
             Assert.Equal(expectedErrorMessage, responseText);
         }
 
-        [Fact(Skip = "Flaky test aspnet/WebHooks#313; see also aspnet/WebHooks#318.")]
+        [Fact]
         public async Task WebHookAction_NoBody_IsBadRequest()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.WebHooks.FunctionalTest/DynamicsCRMCoreReceiverTest.cs
+++ b/test/Microsoft.AspNetCore.WebHooks.FunctionalTest/DynamicsCRMCoreReceiverTest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.WebHooks.FunctionalTest
             }
         }
 
-        [Theory(Skip = "Flaky test aspnet/WebHooks#314; see also aspnet/WebHooks#318.")]
+        [Theory]
         [MemberData(nameof(NonPostDataSet))]
         public async Task WebHookAction_NonPost_IsNotAllowed(HttpMethod method)
         {
@@ -77,7 +77,7 @@ namespace Microsoft.AspNetCore.WebHooks.FunctionalTest
             Assert.Equal(expectedErrorMessage, responseText);
         }
 
-        [Fact(Skip = "Flaky test aspnet/WebHooks#316; see also aspnet/WebHooks#318.")]
+        [Fact]
         public async Task WebHookAction_WrongCode_IsBadRequest()
         {
             // Arrange
@@ -97,7 +97,7 @@ namespace Microsoft.AspNetCore.WebHooks.FunctionalTest
             Assert.Equal(expectedErrorMessage, responseText);
         }
 
-        [Fact(Skip = "Flaky test aspnet/WebHooks#313; see also aspnet/WebHooks#318.")]
+        [Fact]
         public async Task WebHookAction_NoBody_IsBadRequest()
         {
             // Arrange

--- a/test/Microsoft.AspNetCore.WebHooks.FunctionalTest/GitHubCoreReceiverTest.cs
+++ b/test/Microsoft.AspNetCore.WebHooks.FunctionalTest/GitHubCoreReceiverTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNetCore.WebHooks.FunctionalTest
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
-        [Fact(Skip = "Flaky test aspnet/WebHooks#315; see also aspnet/WebHooks#318.")]
+        [Fact]
         public async Task WebHookAction_NoEventHeader_IsNotFound()
         {
             // Arrange
@@ -62,7 +62,7 @@ namespace Microsoft.AspNetCore.WebHooks.FunctionalTest
             }
         }
 
-        [Theory(Skip = "Flaky test aspnet/WebHooks#314; see also aspnet/WebHooks#318.")]
+        [Theory]
         [MemberData(nameof(NonPostDataSet))]
         public async Task WebHookAction_NonPost_IsNotAllowed(HttpMethod method)
         {

--- a/test/Microsoft.AspNetCore.WebHooks.FunctionalTest/SlackCoreReceiverTest.cs
+++ b/test/Microsoft.AspNetCore.WebHooks.FunctionalTest/SlackCoreReceiverTest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNetCore.WebHooks.FunctionalTest
             }
         }
 
-        [Theory(Skip = "Flaky test aspnet/WebHooks#314; see also aspnet/WebHooks#318.")]
+        [Theory]
         [MemberData(nameof(NonPostDataSet))]
         public async Task WebHookAction_NonPost_IsNotAllowed(HttpMethod method)
         {


### PR DESCRIPTION
- not really a #318 fix, especially because it shouldn't be necessary to _globally_ disable this feature

also:
- Upgrade dependencies and KoreBuild to enable local testing of #318 problems
- Revert "Disable flakey tests"
  - not necessary with Global Routing disabled
  - This reverts commit fad82fd.