### PR TITLE
Update README.md to indicate that this repo has merged into aspnet/AspLabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-# Microsoft ASP.NET Core WebHooks
+# Microsoft ASP.NET Core WebHooks [Archived]
+
+**This GitHub project has been archived.** Ongoing development on this prototype can be found in <https://github.com/aspnet/AspLabs>.
+
 ## Note: This repo is solely for the ASP.NET Core WebHooks projects (libraries to consume WebHooks on ASP.NET Core 2.0 and .NET Standard 2.0). For ASP.NET WebHooks (targeting .NET Framework 4.5), see the [aspnet/AspNetWebHooks](https://github.com/aspnet/aspnetwebhooks) repo.
 
-AppVeyor: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/aspnet/webhooks?branch=dev&svg=true)](https://ci.appveyor.com/project/aspnetci/webhooks/branch/dev)
+ASP.NET Core WebHooks provide support for receiving WebHooks. The packages depend on [ASP.NET Core MVC](https://github.com/aspnet/AspNetCore).
 
-Travis:   [![Travis](https://travis-ci.org/aspnet/webhooks.svg?branch=dev)](https://travis-ci.org/aspnet/webhooks)
-
-ASP.NET Core WebHooks provide support for receiving WebHooks. The packages depend on [ASP.NET Core MVC](https://github.com/aspnet/mvc).
-
-ASP.NET Core MVC is part of ASP.NET Core. You can find samples, documentation and getting started instructions for ASP.NET Core at the [Home](https://github.com/aspnet/home) repo.
+ASP.NET Core MVC is part of ASP.NET Core. You can find samples, documentation and getting started instructions for ASP.NET Core at the [AspNetCore](https://github.com/aspnet/AspNetCore) repo.
 
 ### Samples
 - [All Samples](/samples/)


### PR DESCRIPTION
HTTP 301
Location: https://github.com/aspnet/AspLabs

This repository is merging with aspnet/AspLabs. This is part of our broader repo unification work (see https://github.com/aspnet/AspNetCore/issues/3598).

After this PR is merged, this repo will be made read-only and all active development should continue in the aspnet/AspLabs repo.

cref https://github.com/aspnet/AspLabs/pull/29